### PR TITLE
New workshop layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -74,3 +74,5 @@ collections:
     output: false
   workshops:
     output: true
+  meetings:
+    output: true

--- a/_includes/workshops.html
+++ b/_includes/workshops.html
@@ -12,10 +12,22 @@
 
     <div class="row">
         <div class="col-sm-4">
-            <h3>Upcoming events</h3>
+            <h3>Scheduled workshops</h3>
             <ul>
                 {% for workshop in site.workshops %}
                     {% if workshop.status != 'past' %}
+                        <li><a href="{{ workshop.permalink }}">{{ workshop.city }}, {{ workshop.dates }}</a></li>
+                    {% endif %}
+                {% endfor %}
+                <li><a href="http://neic2017.nordforsk.org/workshops/coderefinery/">Umeå, May 29, 2017</a></li>
+            </ul>
+        </div>
+
+        <div class="col-sm-4">
+            <h3>Past workshops</h3>
+            <ul>
+                {% for workshop in site.workshops %}
+                    {% if workshop.status == 'past' %}
                         <li><a href="{{ workshop.permalink }}">{{ workshop.city }}, {{ workshop.dates }}</a></li>
                     {% endif %}
                 {% endfor %}
@@ -25,6 +37,7 @@
         <div class="col-sm-4">
             <h3>Planned workshops</h3>
             <ul>
+                <li>Jun 2017 - Tromsø</li>
                 <li>Oct 2017 - Aarhus</li>
                 <li>Nov 2017 - Linköping</li>
                 <li>Dec 2017 - Helsinki</li>
@@ -36,16 +49,28 @@
             </ul>
         </div>
 
+    </div>
+
+    <div class="row">
         <div class="col-sm-4">
-            <h3>Past workshops and events</h3>
+            <h3>Scheduled events</h3>
             <ul>
-                <li><a href="http://neic2017.nordforsk.org/workshops/coderefinery/">Umeå, May 29, 2017</a></li>
-                {% for workshop in site.workshops %}
-                    {% if workshop.status == 'past' %}
-                        <li><a href="{{ workshop.permalink }}">{{ workshop.city }}, {{ workshop.dates }}</a></li>
+                {% for meeting in site.meetings %}
+                    {% if meeting.status != 'past' %}
+                        <li><a href="{{ meeting.permalink }}">{{ meeting.city }}, {{ meeting.dates }}</a></li>
                     {% endif %}
                 {% endfor %}
-                <li><a href="http://www.uio.no/english/services/it/research/events/coderefinery-2017-april.html">Oslo, April 6, 2017</a></li>
+            </ul>
+        </div>
+
+        <div class="col-sm-4">
+            <h3>Past events</h3>
+            <ul>
+                {% for meeting in site.meetings %}
+                    {% if meeting.status == 'past' %}
+                        <li><a href="{{ meeting.permalink }}">{{ meeting.city }}, {{ meeting.dates }}</a></li>
+                    {% endif %}
+                {% endfor %}
             </ul>
         </div>
     </div>

--- a/_includes/workshops.html
+++ b/_includes/workshops.html
@@ -19,7 +19,6 @@
                         <li><a href="{{ workshop.permalink }}">{{ workshop.city }}, {{ workshop.dates }}</a></li>
                     {% endif %}
                 {% endfor %}
-                <li><a href="http://neic2017.nordforsk.org/workshops/coderefinery/">Umeå, May 29, 2017</a></li>
             </ul>
         </div>
 
@@ -71,6 +70,7 @@
                         <li><a href="{{ meeting.permalink }}">{{ meeting.city }}, {{ meeting.dates }}</a></li>
                     {% endif %}
                 {% endfor %}
+                <li><a href="http://neic2017.nordforsk.org/workshops/coderefinery/">Umeå, May 29, 2017</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
adding events as separate category (everything that's not a regular workshop). this is hopefully more logical than the combination "Upcoming events", "Planned workshops" and "Past workshops and events". #fixes 15

