### PR TITLE
workshop page for reykjavik, rm from Planned

### DIFF
--- a/_workshops/2018-08-21-reykjavik.md
+++ b/_workshops/2018-08-21-reykjavik.md
@@ -1,0 +1,87 @@
+---
+layout: master
+include: workshop-3day-v2
+permalink: /workshops/2018-08-21-reykjavik/
+city: Reykjavik
+dates: August 21-23, 2018
+time: 9:00 am to 5:00 pm
+num_seats: 24
+contact: support@coderefinery.org
+registration_open_date: May 15
+registration_is_closed: false
+registration_form: "https://coderefinery.typeform.com/to/B27XIy"
+status: planned
+instructors:
+    - TBA
+helpers:
+    - TBA
+location: <a href="https://www.openstreetmap.org/way/28631892" target="_blank">"Interaction room" (room 227), Tæknigarður, University of Iceland.</a>
+schedule:
+    - date: Tuesday, August 21
+      software:
+        - title: Bash
+          url: https://coderefinery.github.io/installation/bash/
+        - title: Git
+          url: https://coderefinery.github.io/installation/git/
+        - title: Python
+          url: https://coderefinery.github.io/installation/python/
+        - title: Visual diff tools
+          url: https://coderefinery.github.io/installation/difftools/
+      morning:
+        - title: Welcome and practical information 
+        - title: Introduction to version control - part 1/2
+          url: https://coderefinery.github.io/git-intro/
+      afternoon:
+        - title: Introduction to version control - part 2/2
+          url: https://coderefinery.github.io/git-intro/
+        - title: Documentation
+          url: https://coderefinery.github.io/documentation/
+    - date: Wednesday, August 22
+      software:
+        - title: Bash
+          url: https://coderefinery.github.io/installation/bash/
+        - title: Git
+          url: https://coderefinery.github.io/installation/git/
+        - title: Python
+          url: https://coderefinery.github.io/installation/python/
+        - title: PyCharm
+          url: https://coderefinery.github.io/installation/pycharm/
+        - title: (optional) Docker
+          url: https://coderefinery.github.io/installation/docker/
+      morning:
+        - title: Collaborative distributed version control
+          url: https://coderefinery.github.io/git-collaborative/
+        - title: Archaeology with Git
+          url: https://coderefinery.github.io/git-archaeology/
+      afternoon:
+        - title: Software licensing 
+          url: http://cicero.xyz/v2/remark/github/coderefinery/software-licensing/master/talk.md/
+        - title: Automated testing 
+          url: https://coderefinery.github.io/testing/
+    - date: Thursday, August 23
+      software:
+        - title: Bash
+          url: https://coderefinery.github.io/installation/bash/
+        - title: Git
+          url: https://coderefinery.github.io/installation/git/
+        - title: Python
+          url: https://coderefinery.github.io/installation/python/
+        - title: Compilers
+          url: https://coderefinery.github.io/installation/compilers/
+        - title: Make
+          url: https://coderefinery.github.io/installation/make/
+        - title: CMake
+          url: https://coderefinery.github.io/installation/cmake/
+        - title: Jupyter
+          url: https://coderefinery.github.io/installation/python/#jupyter
+      morning:
+        - title: Jupyter notebooks 
+          url: https://github.com/coderefinery/jupyter
+        - title: Modular code development 
+          url: http://cicero.xyz/v2/remark/github/coderefinery/modular-code-development/master/talk.md/
+      afternoon:
+        - title: Reproducible research 
+          url: https://coderefinery.github.io/reproducible-research/
+        - title: Building portable code with CMake
+          url: https://coderefinery.github.io/cmake/
+---


### PR DESCRIPTION
adding workshop page for Reykjavik, removing it from Planned. Typeform link is correct (i.e. a new one)