### PR TITLE
move testing to day 3

### DIFF
--- a/_workshops/2018-05-29-espoo.md
+++ b/_workshops/2018-05-29-espoo.md
@@ -75,8 +75,6 @@ schedule:
           url: https://coderefinery.github.io/IDEs/
         - title: Reproducible research (Harsha)
           url: https://coderefinery.github.io/reproducible-research/
-        - title: Automated testing (Jyry)
-          url: https://coderefinery.github.io/testing/
     - date: Thursday, May 31
       software:
         - title: Bash
@@ -95,6 +93,8 @@ schedule:
       afternoon:
         - title: Software licensing (Jyry)
           url: http://cicero.xyz/v2/remark/github/coderefinery/software-licensing/master/talk.md/
-        - title: Jupyter notebooks continued (Jyry)
+        - title: Automated testing (Jyry)
+          url: https://coderefinery.github.io/testing/
+        - title: Jupyter notebooks continued (if there is time, Jyry)
           url: https://github.com/coderefinery/jupyter
 ---


### PR DESCRIPTION
We decided to move testing to day 3 to avoid running long on day 2. Pandas is not core content so it can be cut down if necessary.