### PR TITLE
added info about carpentries membership

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -3,10 +3,28 @@
     <div class="col-sm-6">
       <h3 class="text-center top-space">Training</h3>
       <p>
-        We offer training workshops to researchers from Nordic research groups and projects in using
-        state-of-the-art tools and practices from modern collaborative software
-        engineering. Our three-day workshops focus on methods to build modular,
-	reusable, maintainable, sustainable, reproducible, testable, and robust software.
+      The key objective of CodeRefinery is to grow researchers' software best practices
+      skills to facilitate open and reproducible research.
+
+      We offer training opportunities to researchers from Nordic research groups and projects 
+      to learn basic-to-advanced research computing skills and become confident in using
+      state-of-the-art tools and practices from modern collaborative software
+      engineering. 
+
+      Since september 2018, <a href="https://neic.no/">NeIC</a> is a <a href="https://carpentries.org/members/">Platinum Partner</a> to <a href="https://carpentries.org">The Carpentries</a>,      an international successful project that comprises <a href="https://software-carpentry.org/">Software Carpentry</a> and <a href="http://www.datacarpentry.org/">Data Carpentry</a>,
+      communities of Instructors, Trainers, Maintainers, helpers, and supporters who share a mission to teach foundational computational and data science skills to researchers.
+      
+      
+      Our training offering has been extended and we offer:
+
+      <ul>
+        <li><a href="https://carpentries.org/workshops/">Carpentries workshops</a></li>
+        <li>Three-day workshops that focus on advanced methods to build modular,
+	reusable, maintainable, sustainable, reproducible, testable, and robust software.</li>
+	<li>Train the trainer program to build partnerships with Research Software Engineers and researchers who are willing to lead skills' transfer within their local communities in the Nordics.
+	</li>
+      </ul>
+
       </p>
       <h3 class="text-center top-space">Who is it for?</h3>
       <p>
@@ -29,7 +47,10 @@
       <br>
       <h3 class="text-center top-space">Level of our workshops</h3>
       <p>
-	It is assumed that participants already write code
+	Carpentries workshops focus on creating a motivating and engaging environment for 
+	learners with no or little digital skills while our three day workshops are the next
+	step.
+	For CodeRefinery workshop, it is assumed that participants already write code
 	for their research but no expertise is required.
 	Some experience in navigating the file tree and editing
 	files in a terminal session is recommended.


### PR DESCRIPTION
I was not sure where you wanted to add information about Carpentries membership: I added it in the Training section. 
I wonder if we should put more emphasis on the CodeRefinery strategic roadmap to explain more what we want to achieve, and how we plan to become sustainable.