### PR TITLE
remove optional docker installation

### DIFF
--- a/_workshops/2019-03-25-stockholm.md
+++ b/_workshops/2019-03-25-stockholm.md
@@ -42,8 +42,6 @@ software:
     url: https://coderefinery.github.io/installation/python/#jupyter
   - title: Snakemake
     url: https://coderefinery.github.io/installation/python/#snakemake
-  - title: (optional) Docker
-    url: https://coderefinery.github.io/installation/docker/
   - title: Accounts
     url: https://coderefinery.github.io/installation/#accounts
 

--- a/_workshops/2019-04-02-tartu.md
+++ b/_workshops/2019-04-02-tartu.md
@@ -45,8 +45,6 @@ software:
     url: https://coderefinery.github.io/installation/python/#jupyter
   - title: Snakemake
     url: https://coderefinery.github.io/installation/python/#snakemake
-  - title: (optional) Docker
-    url: https://coderefinery.github.io/installation/docker/
   - title: Accounts
     url: https://coderefinery.github.io/installation/#accounts
 

--- a/_workshops/2019-05-21-gothenburg.md
+++ b/_workshops/2019-05-21-gothenburg.md
@@ -43,8 +43,6 @@ software:
     url: https://coderefinery.github.io/installation/python/#jupyter
   - title: Snakemake
     url: https://coderefinery.github.io/installation/python/#snakemake
-  - title: (optional) Docker
-    url: https://coderefinery.github.io/installation/docker/
   - title: Accounts
     url: https://coderefinery.github.io/installation/#accounts
 

--- a/_workshops/2019-05-27-helsinki.md
+++ b/_workshops/2019-05-27-helsinki.md
@@ -70,8 +70,6 @@ software:
          url: https://coderefinery.github.io/installation/python/#jupyter
        - title: Snakemake
          url: https://coderefinery.github.io/installation/python/#snakemake
-       - title: (optional) Docker
-         url: https://coderefinery.github.io/installation/docker/
        - title: Accounts
          url: https://coderefinery.github.io/installation/#accounts
 

--- a/_workshops/2019-06-03-oslo.md
+++ b/_workshops/2019-06-03-oslo.md
@@ -68,8 +68,6 @@ software:
          url: https://coderefinery.github.io/installation/python/#jupyter
        - title: Snakemake
          url: https://coderefinery.github.io/installation/python/#snakemake
-       - title: (optional) Docker
-         url: https://coderefinery.github.io/installation/docker/
        - title: Accounts
          url: https://coderefinery.github.io/installation/#accounts
 


### PR DESCRIPTION
even if it's listed as an optional installation it still feels unnecessary to include it, since the hands-on part which would be possible to do would require massive downloads and building (the base ubuntu image),
which takes long time and isn't really desirable