### PR TITLE
Add a basic nudge to partnerships on the contact page

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -37,6 +37,16 @@ All [CodeRefinery training material](../lessons) is made available under the [Cr
 
 Except where otherwise noted, the example programs and other software provided by [CodeRefinery](https://github.com/coderefinery/) are made available under the [OSI](https://opensource.org/)-approved [MIT license](https://opensource.org/licenses/mit-license.html).
 
+### Become a partner
+
+Coderefinery started as a sponsored and funded project, but we are
+encouraging more partnerships to stay sustainable long-term.  In
+general, we image a reciprocal relationship for academic institutions:
+you help us run workshops, we give workshops at your institution.
+Join our chat (Zulip, below) and talk to us.  There's no formal
+process yet and we don't even know exactly how it will work, so join
+and have some influence.
+
 
 ## Contact us
 

--- a/workshop-requirements.md
+++ b/workshop-requirements.md
@@ -40,7 +40,6 @@ possible workshop helpers. Good candidates are people who:
 - have a passion for teaching, scientific software development, open source, open science, etc.
 
 
-
 ## Other requirements
 
 When we organize a workshop or event at a new site, we may need help with some local arrangements,
@@ -49,3 +48,9 @@ including:
 - Booking a lecture room.
 - Ordering coffee and refreshments.
 - Advertise the workshop through local dissemination channels.
+
+
+## After the workshop
+
+Would you like to [become a helper, instructor, or partner](/contact/)
+and make more workshops possible?


### PR DESCRIPTION
- Along with "be a helper", "be an instructor".
- Add link to this on the workshop-requirements page, since I guess
  that's what we'll send to local organizers most often.