### PR TITLE
add tinyletter email field for people to sign up for newsletter

### DIFF
--- a/outreach.md
+++ b/outreach.md
@@ -4,6 +4,18 @@ include: content
 title: Outreach activities, presentations, and articles
 ---
 
+## The CodeRefinery Newsletter
+
+The CodeRefinery Newsletter is sent out roughly every two months.
+Subscribers will be informed about upcoming workshops, hackathons and 
+other events, as well as other interesting developments like new training 
+material, community building activities and general project 
+updates. To sign up, please enter your email address below (or visit 
+[tinyletter.com/coderefinery](https://tinyletter.com/coderefinery)).
+<form style="border:1px solid #ccc;padding:3px;text-align:center;" action="https://tinyletter.com/coderefinery" method="post" target="popupwindow" onsubmit="window.open('https://tinyletter.com/coderefinery', 'popupwindow', 'scrollbars=yes,width=800,height=600');return true"><p><label for="tlemail">Enter your email address</label></p><p><input type="text" style="width:140px" name="email" id="tlemail" /></p><input type="hidden" value="1" name="embed"/><input type="submit" value="Subscribe" /><p><a href="https://tinyletter.com" target="_blank">powered by TinyLetter</a></p></form>
+         
+
+
 ## Presentations
 
 - Dalton meeting 2016, Uppsala (Radovan Bast)


### PR DESCRIPTION
a coderefinery account has been set up on TinyLetter, and a sign-up button generated there. Currently all new sign-ups will result in an email to support@coderefinery but this can be changed at any time 