### PR TITLE
reorganize workshop page to make future workshops/events more visible

### DIFF
--- a/_events/2019-11-06-stockholm.md
+++ b/_events/2019-11-06-stockholm.md
@@ -1,14 +1,14 @@
 ---
 layout: master
 include: hackathon
-permalink: /workshops/2019-11-06-stockholm/
-city: Stockholm
+permalink: /events/2019-11-06-stockholm/
+city: Stockholm hackathon
 dates: November 6-7, 2019
 time: 9:00 am to 5:00 pm
 num_seats: 30
 contact: support@coderefinery.org
 registration_open_date: June 31
-registration_is_closed: false
+registration_is_closed: true
 registration_form: "https://indico.neic.no/event/89/"
 description:
   Welcome to the first CodeRefinery hackathon! The idea behind this event 

--- a/_includes/workshops.html
+++ b/_includes/workshops.html
@@ -50,7 +50,7 @@
 
     <div class="row">
         <div class="col-sm-6">
-            <h3>Future 3-day workshops</h3>
+            <h3>Upcoming workshops and events</h3>
             <ul>
                 {% for event in site.workshops reversed %}
                   {% capture nowyear %}{{'now' | date: '%Y'}}{% endcapture %}
@@ -68,7 +68,29 @@
                     {% endif %}
                   {% endif %}
                 {% endfor %}
+
+                {% for event in site.events reversed %}
+                  {% capture nowyear %}{{'now' | date: '%Y'}}{% endcapture %}
+                  {% capture nowday %}{{'now' | date: '%j'}}{% endcapture %}
+                  {% capture postmonth %}{{event.dates | date: '%b'}}{% endcapture %}
+                  {% capture postday %}{{event.dates | date: '%j'}}{% endcapture %}
+                  {% capture postyear %}{{event.dates | split: ", " | last }}{% endcapture %}
+                  {% assign postday = postday | plus: 0 %}
+                  {% assign nowday = nowday | minus: 2 %}
+                  {% if postyear > nowyear or postday >= nowday and postyear >= nowyear %}
+                    {% if event.permalink %}
+                        <li><a href="{{ event.permalink }}" target="_blank">{{ event.city }}, {{ event.dates }}</a></li>
+                    {% else %}
+                        <li>{{ event.city }}, {{ event.dates }}</li>
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+
             </ul>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
             <h3>Past 3-day workshops</h3>
             <ul>
                 {% for event in site.workshops reversed %}
@@ -91,9 +113,18 @@
         </div>
 
         <div class="col-sm-6">
-            <h3>Shorter workshops and other events</h3>
+            <h3>Past events and shorter workshops</h3>
             <ul>
                 {% for event in site.events reversed %}
+                  {% capture nowyear %}{{'now' | date: '%Y'}}{% endcapture %}
+                  {% capture nowday %}{{'now' | date: '%j'}}{% endcapture %}
+                  {% capture postmonth %}{{event.dates | date: '%b'}}{% endcapture %}
+                  {% capture postday %}{{event.dates | date: '%j'}}{% endcapture %}
+                  {% capture postyear %}{{event.dates | split: ", " | last }}{% endcapture %}
+                  {% assign postday = postday | plus: 0 %}
+                  {% assign nowday = nowday | minus: 2 %}
+                  {% if postyear < nowyear or postyear <= nowyear and postday < nowday %}
+
                     {% if event.link %}
                         <li><a href="{{ event.link }}" target="_blank">{{ event.city }}, {{ event.dates }}</a></li>
                     {% elsif event.permalink %}
@@ -101,6 +132,8 @@
                     {% else %}
                         <li>{{ event.city }}, {{ event.dates }}</li>
                     {% endif %}
+
+                  {% endif %}
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
all future workshops and events will be shown on top, past workshops and events will be separated into two "past" categories