### PR TITLE
add instructor training page and introduce further variables

### DIFF
--- a/_events/2019-11-04-stockholm.md
+++ b/_events/2019-11-04-stockholm.md
@@ -3,6 +3,9 @@ layout: master
 include: hackathon
 permalink: /events/2019-11-04-stockholm/
 city: Stockholm
+type: instructor training workshop
+subtitle: Learning to teach tools and best practices in research software development
+whofor: If you want to become a CodeRefinery instructor or simply improve the way you teach best practices and tooling in research software development, then you might want to attend this instructor training workshop!
 dates: November 4-5, 2019
 time: 9:00 am to 5:00 pm
 num_seats: 30
@@ -34,7 +37,7 @@ description:
   event at KTH where researchers are invited to bring their code and data
   and work on it collaboratively with other participants. 
   We would like to bring over ideas from the instructor workshop to the 
-  hackathon, so participants of this workshop are especially invited 
+  hackathon, so participants of this workshop are especially encouraged
   to attend also the hackathon to work on lesson improvement and development 
   of new CodeRefinery lessons!
   </p>

--- a/_events/2019-11-04-stockholm.md
+++ b/_events/2019-11-04-stockholm.md
@@ -1,0 +1,61 @@
+---
+layout: master
+include: hackathon
+permalink: /events/2019-11-04-stockholm/
+city: Stockholm
+dates: November 4-5, 2019
+time: 9:00 am to 5:00 pm
+num_seats: 30
+contact: support@coderefinery.org
+registration_open_date: June 31
+registration_is_closed: false
+registration_form: "https://indico.neic.no/event/89/"
+description:
+  <p>
+  Are you interested in becoming an instructor in CodeRefinery workshops?
+  Are you teaching a university course and would like to include 
+  aspects of best practices in software engineering in the course?
+  Or would you simply like to educate your friends and colleagues in 
+  how to write more reusable, reproducible and better documented code?
+  </p>
+  <p>
+  If you answered yes to any of the above questions, we welcome you to 
+  join the first CodeRefinery instructor training workshop! This workshop
+  will focus on how to teach technical topics (e.g. version control with 
+  Git, automated testing or programming languages) in general, and 
+  CodeRefinery lessons in particular. We will cover key pedagogical ideas
+  and teaching methods, and what you need to know in order to teach the 
+  CodeRefinery lessons. All the material will be firmly grounded in the 
+  experience that CodeRefinery staff has acquired after teaching over 25
+  workshops to over 600 participants.
+  </p>
+  <p>
+  This instructor training workshop will immediate precede a hackathon 
+  event at KTH where researchers are invited to bring their code and data
+  and work on it collaboratively with other participants. 
+  We would like to bring over ideas from the instructor workshop to the 
+  hackathon, so participants of this workshop are especially invited 
+  to attend also the hackathon to work on lesson improvement and development 
+  of new CodeRefinery lessons!
+  </p>
+organizers:
+  - Radovan Bast
+  - Anne-Claire Fouilloux
+  - Thor Wikfeldt
+location: Fantum room, Lindstedtsvägen 24, F-huset, floor 5, KTH Campus.
+
+schedule:
+  - date: Monday, November 4 
+    morning:
+      - title: Arrival
+    afternoon:
+      - title: Welcome and general introduction
+      - title: Instructor training part I
+  - date: Tuesday, November 5
+    morning:
+      - title: Instructor training part II
+    afternoon:
+      - title: Instructor training part III
+      - title: Brainstorming about new lessons, preparation for hackathon
+
+---

--- a/_events/2019-11-06-stockholm.md
+++ b/_events/2019-11-06-stockholm.md
@@ -1,14 +1,14 @@
 ---
 layout: master
 include: hackathon
-permalink: /workshops/2019-11-06-stockholm/
-city: Stockholm
+permalink: /events/2019-11-06-stockholm/
+city: Stockholm hackathon
 dates: November 6-7, 2019
 time: 9:00 am to 5:00 pm
 num_seats: 30
 contact: support@coderefinery.org
 registration_open_date: June 31
-registration_is_closed: false
+registration_is_closed: true
 registration_form: "https://indico.neic.no/event/89/"
 description:
   Welcome to the first CodeRefinery hackathon! The idea behind this event 

--- a/_events/2019-11-06-stockholm.md
+++ b/_events/2019-11-06-stockholm.md
@@ -2,7 +2,10 @@
 layout: master
 include: hackathon
 permalink: /events/2019-11-06-stockholm/
-city: Stockholm hackathon
+city: Stockholm 
+type: hackathon
+subtitle: Building a Nordic community of research software engineers
+whofor: If you are writing code, working with data or teaching technical topics in a research environment, then you might want to attend this hackathon!
 dates: November 6-7, 2019
 time: 9:00 am to 5:00 pm
 num_seats: 30

--- a/_includes/hackathon.html
+++ b/_includes/hackathon.html
@@ -1,8 +1,8 @@
 <div class="container mtb">
     <div class="row">
         <div class="col-sm-12">
-            <h1>CodeRefinery hackathon in {{ page.city }}</h1>
-            <h4>Building a Nordic community of research software engineers</h4>
+            <h1>CodeRefinery {{ page.type }} in {{ page.city }}</h1>
+            <h4>{{ page.subtitle }}</h4>
 
             <h3>Description</h3>
             <p>
@@ -77,7 +77,7 @@
 
             <h3>Who should join?</h3>
             <p>
-                If you are writing code that is used in research, then you might want to attend this hackathon.
+                {{ page.whofor }}
             </p>
 
             <h3>Organizers</h3>

--- a/_includes/workshops.html
+++ b/_includes/workshops.html
@@ -50,7 +50,7 @@
 
     <div class="row">
         <div class="col-sm-6">
-            <h3>Future 3-day workshops</h3>
+            <h3>Upcoming workshops and events</h3>
             <ul>
                 {% for event in site.workshops reversed %}
                   {% capture nowyear %}{{'now' | date: '%Y'}}{% endcapture %}
@@ -68,7 +68,29 @@
                     {% endif %}
                   {% endif %}
                 {% endfor %}
+
+                {% for event in site.events reversed %}
+                  {% capture nowyear %}{{'now' | date: '%Y'}}{% endcapture %}
+                  {% capture nowday %}{{'now' | date: '%j'}}{% endcapture %}
+                  {% capture postmonth %}{{event.dates | date: '%b'}}{% endcapture %}
+                  {% capture postday %}{{event.dates | date: '%j'}}{% endcapture %}
+                  {% capture postyear %}{{event.dates | split: ", " | last }}{% endcapture %}
+                  {% assign postday = postday | plus: 0 %}
+                  {% assign nowday = nowday | minus: 2 %}
+                  {% if postyear > nowyear or postday >= nowday and postyear >= nowyear %}
+                    {% if event.permalink %}
+                        <li><a href="{{ event.permalink }}" target="_blank">{{ event.city }}, {{ event.dates }}</a></li>
+                    {% else %}
+                        <li>{{ event.city }}, {{ event.dates }}</li>
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+
             </ul>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
             <h3>Past 3-day workshops</h3>
             <ul>
                 {% for event in site.workshops reversed %}
@@ -91,9 +113,18 @@
         </div>
 
         <div class="col-sm-6">
-            <h3>Shorter workshops and other events</h3>
+            <h3>Past events and shorter workshops</h3>
             <ul>
                 {% for event in site.events reversed %}
+                  {% capture nowyear %}{{'now' | date: '%Y'}}{% endcapture %}
+                  {% capture nowday %}{{'now' | date: '%j'}}{% endcapture %}
+                  {% capture postmonth %}{{event.dates | date: '%b'}}{% endcapture %}
+                  {% capture postday %}{{event.dates | date: '%j'}}{% endcapture %}
+                  {% capture postyear %}{{event.dates | split: ", " | last }}{% endcapture %}
+                  {% assign postday = postday | plus: 0 %}
+                  {% assign nowday = nowday | minus: 2 %}
+                  {% if postyear < nowyear or postyear <= nowyear and postday < nowday %}
+
                     {% if event.link %}
                         <li><a href="{{ event.link }}" target="_blank">{{ event.city }}, {{ event.dates }}</a></li>
                     {% elsif event.permalink %}
@@ -101,6 +132,8 @@
                     {% else %}
                         <li>{{ event.city }}, {{ event.dates }}</li>
                     {% endif %}
+
+                  {% endif %}
                 {% endfor %}
             </ul>
         </div>

--- a/_includes/workshops.html
+++ b/_includes/workshops.html
@@ -79,9 +79,9 @@
                   {% assign nowday = nowday | minus: 2 %}
                   {% if postyear > nowyear or postday >= nowday and postyear >= nowyear %}
                     {% if event.permalink %}
-                        <li><a href="{{ event.permalink }}" target="_blank">{{ event.city }}, {{ event.dates }}</a></li>
+                        <li><a href="{{ event.permalink }}" target="_blank">{{ event.city }} {{ event.type }}, {{ event.dates }}</a></li>
                     {% else %}
-                        <li>{{ event.city }}, {{ event.dates }}</li>
+                        <li>{{ event.city }} {{ event.type }}, {{ event.dates }}</li>
                     {% endif %}
                   {% endif %}
                 {% endfor %}
@@ -126,9 +126,9 @@
                   {% if postyear < nowyear or postyear <= nowyear and postday < nowday %}
 
                     {% if event.link %}
-                        <li><a href="{{ event.link }}" target="_blank">{{ event.city }}, {{ event.dates }}</a></li>
+                        <li><a href="{{ event.link }}" target="_blank">{{ event.city }} {{ event.type }}, {{ event.dates }}</a></li>
                     {% elsif event.permalink %}
-                        <li><a href="{{ event.permalink }}" target="_blank">{{ event.city }}, {{ event.dates }}</a></li>
+                        <li><a href="{{ event.permalink }}" target="_blank">{{ event.city }} {{ event.type }}, {{ event.dates }}</a></li>
                     {% else %}
                         <li>{{ event.city }}, {{ event.dates }}</li>
                     {% endif %}


### PR DESCRIPTION
in order to distinguish the hackathon and instructor training workshops, without adding further templates, it was necessary to introduce more site variables (page.type, page.subtitle, page.whofor)

the description on the instructor training page should be refined 