### PR TITLE
Created RSS feeds for workshops and events (one feed each)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,4 +23,7 @@
         <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <link type="application/atom+xml" rel="alternate" href="{{ site.url }}{{ site.baseurl }}/feed-workshops/index.xml" title="CodeRefinery workshops" />
+    <link type="application/atom+xml" rel="alternate" href="{{ site.url }}{{ site.baseurl }}/feed-events/index.xml" title="Events"/>
 </head>

--- a/_includes/workshops.html
+++ b/_includes/workshops.html
@@ -17,6 +17,7 @@
 		Sign up
                 <a href="https://goo.gl/forms/DLp3d0CzkAnwS2GX2" target="_blank">here</a>
                 and we will notify you when the registration to a workshop or event near you opens.
+                Or subscribe to our <a href="../feed-workshops/">workshops</a> and <a href="../feed-events/">events</a> RSS feeds.
             </p>
 
             <h3>Requesting a workshop<a name="request_workshop"></a> </h3>

--- a/feed-events.xml
+++ b/feed-events.xml
@@ -14,14 +14,14 @@ layout: null
 
   <title type="html">Events</title>
 
-  {% assign events = site.events | where_exp: "post", "post.draft != true" | reverse %}
+  {% assign events = site.events | where_exp: "post", "post.draft != true" | sort: "published_date"  | reverse %}
   {% for event in events limit: 30 %}
     <entry{% if event.lang %}{{" "}}xml:lang="{{ event.lang }}"{% endif %}>
       <title type="html">{{ event.city | append: ", " | append: event.dates | smartify | strip_html | normalize_whitespace | xml_escape }}</title>
       <id>{{ event.id | absolute_url | xml_escape }}</id>
-      <updated>{{ event.last_modified_at | default: event.date | date_to_xmlschema }}</updated>
+      <updated>{{ event.last_modified_at | default: event.published_date | date_to_xmlschema }}</updated>
       <link href="{{ event.url | absolute_url }}" rel="alternate" type="text/html" title="{{ event.city | xml_escape }}" />
-      <published>{{ event.date | date_to_xmlschema }}</published>
+      <published>{{ event.published_date | date_to_xmlschema }}</published>
       <content type="xhtml" xml:base="{{ event.url | absolute_url | xml_escape }}">
         <div xmlns="http://www.w3.org/1999/xhtml">
           {{ event.content }}

--- a/feed-events.xml
+++ b/feed-events.xml
@@ -1,0 +1,39 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="utf-8"?>
+{% if page.xsl %}
+  <?xml-stylesheet type="text/xml" href="{{ '/feed.xslt.xml' | absolute_url }}"?>
+{% endif %}
+<feed xmlns="http://www.w3.org/2005/Atom" {% if site.lang %}xml:lang="{{ site.lang }}"{% endif %}>
+  <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
+  <link href="{{ page.url | absolute_url }}" rel="self" type="application/atom+xml" />
+  <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html" {% if site.lang %}hreflang="{{ site.lang }}" {% endif %}/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ page.url | absolute_url | xml_escape }}</id>
+
+  <title type="html">Events</title>
+
+  {% assign events = site.events | where_exp: "post", "post.draft != true" | reverse %}
+  {% for event in events limit: 30 %}
+    <entry{% if event.lang %}{{" "}}xml:lang="{{ event.lang }}"{% endif %}>
+      <title type="html">{{ event.city | append: ", " | append: event.dates | smartify | strip_html | normalize_whitespace | xml_escape }}</title>
+      <id>{{ event.id | absolute_url | xml_escape }}</id>
+      <updated>{{ event.last_modified_at | default: event.date | date_to_xmlschema }}</updated>
+      <link href="{{ event.url | absolute_url }}" rel="alternate" type="text/html" title="{{ event.city | xml_escape }}" />
+      <published>{{ event.date | date_to_xmlschema }}</published>
+      <content type="xhtml" xml:base="{{ event.url | absolute_url | xml_escape }}">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+          {{ event.content }}
+          {% if event.location and event.location != empty %}
+            {{ event.location | strip_html | normalize_whitespace }}<br /> 
+          {% endif %}
+          {% if event.instructors and event.instructors != empty %}
+            Instructors: {{ event.instructors | array_to_sentence_string | normalize_whitespace }}<br />
+          {% endif %}
+          <a href="{{ event.link | absolute_url | xml_escape }}">{{ event.link | absolute_url | xml_escape }}</a>
+        </div>
+      </content>
+    </entry>
+  {% endfor %}
+</feed>

--- a/feed-workshops.xml
+++ b/feed-workshops.xml
@@ -15,14 +15,14 @@ layout: null
   <title type="html">CodeRefinery workshops</title>
   <subtitle>Training and e-Infrastructure for Research Software Development</subtitle>
 
-  {% assign workshops = site.workshops | where_exp: "post", "post.draft != true" | reverse %}
+  {% assign workshops = site.workshops | where_exp: "post", "post.draft != true" | sort: "published_date" | reverse %}
   {% for workshop in workshops limit: 30 %}
     <entry{% if workshop.lang %}{{" "}}xml:lang="{{ workshop.lang }}"{% endif %}>
       <title type="html">{{ workshop.city | append: ", " | append: workshop.dates | smartify | strip_html | normalize_whitespace | xml_escape }}</title>
       <id>{{ workshop.id | absolute_url | xml_escape }}</id>
-      <updated>{{ workshop.last_modified_at | default: workshop.date | date_to_xmlschema }}</updated>
-      <link href="{{ workshop.url | absolute_url }}" rel="alternate" type="text/html" title="{{ workshop.title | xml_escape }}" />
-      <published>{{ workshop.registration_open_date | date_to_xmlschema }}</published>
+      <updated>{{ workshop.last_modified_at | default: workshop.published_date | date_to_xmlschema }}</updated>
+      <link href="{{ workshop.url | absolute_url }}" rel="alternate" type="text/html" title="{{ workshop.city | xml_escape }}" />
+      <published>{{ workshop.published_date | date_to_xmlschema }}</published>
       <content type="xhtml" xml:base="{{ workshop.url | absolute_url | xml_escape }}">
         <div xmlns="http://www.w3.org/1999/xhtml">
           {% if workshop.location and workshop.location != empty %}

--- a/feed-workshops.xml
+++ b/feed-workshops.xml
@@ -1,0 +1,42 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="utf-8"?>
+{% if page.xsl %}
+  <?xml-stylesheet type="text/xml" href="{{ '/feed.xslt.xml' | absolute_url }}"?>
+{% endif %}
+<feed xmlns="http://www.w3.org/2005/Atom" {% if site.lang %}xml:lang="{{ site.lang }}"{% endif %}>
+  <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
+  <link href="{{ page.url | absolute_url }}" rel="self" type="application/atom+xml" />
+  <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html" {% if site.lang %}hreflang="{{ site.lang }}" {% endif %}/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ page.url | absolute_url | xml_escape }}</id>
+
+  <title type="html">CodeRefinery workshops</title>
+  <subtitle>Training and e-Infrastructure for Research Software Development</subtitle>
+
+  {% assign workshops = site.workshops | where_exp: "post", "post.draft != true" | reverse %}
+  {% for workshop in workshops limit: 30 %}
+    <entry{% if workshop.lang %}{{" "}}xml:lang="{{ workshop.lang }}"{% endif %}>
+      <title type="html">{{ workshop.city | append: ", " | append: workshop.dates | smartify | strip_html | normalize_whitespace | xml_escape }}</title>
+      <id>{{ workshop.id | absolute_url | xml_escape }}</id>
+      <updated>{{ workshop.last_modified_at | default: workshop.date | date_to_xmlschema }}</updated>
+      <link href="{{ workshop.url | absolute_url }}" rel="alternate" type="text/html" title="{{ workshop.title | xml_escape }}" />
+      <published>{{ workshop.registration_open_date | date_to_xmlschema }}</published>
+      <content type="xhtml" xml:base="{{ workshop.url | absolute_url | xml_escape }}">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+          {% if workshop.location and workshop.location != empty %}
+            {{ workshop.location | strip_html | normalize_whitespace }}<br />
+          {% endif %}
+          {% if workshop.instructors and workshop.instructors != empty %}
+            Course instructors: {{ workshop.instructors | array_to_sentence_string | normalize_whitespace }}<br />
+          {% endif %}
+          {% if workshop.helpers and workshop.helpers != empty %}
+            Course helpers: {{ workshop.helpers | array_to_sentence_string | normalize_whitespace }}
+          {% endif %}
+          <p /><a href="{{ workshop.url | absolute_url | xml_escape }}">Read more about this workshop on CodeRefinery.org</a>
+        </div>
+      </content>
+    </entry>
+  {% endfor %}
+</feed>


### PR DESCRIPTION
I managed to accomplish a separate feed each for workshops and events. Other collections had a markedly different structure, and are not as useful to receive updates about (in my estimation) so I did not bother with those.

I actually tried to create a "master" RSS feed containing both workshops and events, but I did not manage to make it render anything. Just goes to show how poorly I grasp Liquid tags. But two feeds are better than none, I reckon ;-)

I based the `feed-*.xml` files on [that specified by the `jekyll-feed` plugin](https://github.com/jekyll/jekyll-feed/blob/master/lib/jekyll-feed/feed.xml).

I have tested this on a freshly provisioned Ubuntu 18.04 box, with Ruby v2.5.1p57, Gem v2.7.6 and Jekyll v3.8.5 and the feeds render OK, are auto-discoverable by Firefox, and the links in the feed appear to work. I have also added a sentence advertising the feeds under "Notify me" (for those site visitors who use browsers that don't auto-discover feeds).

Please note that the code in `feed-*.xml` could be made more robust if *all* events and workshops used a properly formatted ISO date in the same field. The field `registration_open_date` is a close match, but cannot be relied on since it does not always specify a year. If I may propose one change to the site, it would be to include a `published_date` field using an ISO formatted date in all post frontmatters.

Just for reference:
- https://github.com/jekyll/jekyll-feed/
- https://thomascfoulds.com/2018/05/31/rss-feeds-by-collection-in-jekyll.html
- https://protesilaos.com/codelog/looping-collections/