### PR TITLE
Espoo 2019 workshop registration link

### DIFF
--- a/_workshops/2019-12-10-espoo.md
+++ b/_workshops/2019-12-10-espoo.md
@@ -7,7 +7,7 @@ city: Espoo
 dates: December 10-12, 2019
 time: 9:00 am to 5:00 pm
 num_seats: 45
-#participants: 20
+participants: Open
 contact: support@coderefinery.org
 registration_open_date: October 1
 registration_is_closed: false

--- a/_workshops/2019-12-10-espoo.md
+++ b/_workshops/2019-12-10-espoo.md
@@ -11,7 +11,7 @@ num_seats: 45
 contact: support@coderefinery.org
 registration_open_date: October 1
 registration_is_closed: false
-#registration_form: FIXME
+registration_form: "https://indico.neic.no/event/104/"
 goals:
     The aim of this course is to demonstrate to and familiarize
     the workshop participants with best practices and tools in modern research

--- a/_workshops/2019-12-10-espoo.md
+++ b/_workshops/2019-12-10-espoo.md
@@ -1,6 +1,5 @@
 ---
 layout: master
-exclude: true  # remove this line to render the page on the website
 include: workshop-3day
 permalink: /workshops/2019-12-10-espoo/
 published_date: 2019-08-01


### PR DESCRIPTION
I created the even on indico for Espoo workshop as the registration should be open tomorrow.
I opened the registration for 60 people however I will not have time to manage and approve all.
@rkdarst @bast or @juholehtonen can you take on the registration management.

Both registration and survey should be open on October 1st at: https://indico.neic.no/event/104