### PR TITLE
Fix links page margins

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -1,5 +1,5 @@
 <div class="container mb">
-  <div class="row">
+  <div>
     <div class="col">
       <div class="two_columns">
         {% for section in site.links %}


### PR DESCRIPTION
The links page had inconsistent margins for the main content compared with the rest of the pages.

Not a big deal just a proposal to have things a bit more consistent.

**Before:**
![image](https://user-images.githubusercontent.com/47524/66286113-9b718980-e8d8-11e9-8d72-6c7d38505dc5.png)


----

**After:**

![image](https://user-images.githubusercontent.com/47524/66286103-8dbc0400-e8d8-11e9-860f-16d9cc1b4ac6.png)
