### PR TITLE
Update links to installation instructions

### DIFF
--- a/_events/2019-03-05-copenhagen.md
+++ b/_events/2019-03-05-copenhagen.md
@@ -33,7 +33,7 @@ go through the following installation and configuration instructions.
   - [Git](https://coderefinery.github.io/installation/git/)
   - [Python](https://coderefinery.github.io/installation/python/)
   - [JupyterLab](https://coderefinery.github.io/installation/jupyter)
-  - [Accounts](https://coderefinery.github.io/installation/#accounts)
+  - [Accounts](https://coderefinery.github.io/installation/accounts)
   - [Common installation and configuration problems](https://coderefinery.github.io/installation/troubleshooting/)
 
 

--- a/_events/2019-09-09-stockholm.md
+++ b/_events/2019-09-09-stockholm.md
@@ -43,7 +43,7 @@ go through the following installation and configuration instructions.
 - [Python](https://coderefinery.github.io/installation/python/)
 - [(optional) Visual diff tools](https://coderefinery.github.io/installation/difftools/)
 - [Snakemake](https://coderefinery.github.io/installation/snakemake)
-- [Accounts](https://coderefinery.github.io/installation/#accounts)
+- [Accounts](https://coderefinery.github.io/installation/accounts)
 - [Common installation and configuration problems](https://coderefinery.github.io/installation/troubleshooting/)
 
 ### Schedule

--- a/_workshops/2018-12-03-uppsala.md
+++ b/_workshops/2018-12-03-uppsala.md
@@ -47,7 +47,7 @@ software:
   - title: (optional) Docker
     url: https://coderefinery.github.io/installation/docker/
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Monday, December 3

--- a/_workshops/2018-12-11-espoo.md
+++ b/_workshops/2018-12-11-espoo.md
@@ -61,7 +61,7 @@ software:
   - title: (optional) Docker
     url: https://coderefinery.github.io/installation/docker/
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Tuesday, December 11

--- a/_workshops/2019-03-25-stockholm.md
+++ b/_workshops/2019-03-25-stockholm.md
@@ -45,7 +45,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Monday, March 25

--- a/_workshops/2019-04-02-tartu.md
+++ b/_workshops/2019-04-02-tartu.md
@@ -48,7 +48,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Tuesday, April 2

--- a/_workshops/2019-05-21-gothenburg.md
+++ b/_workshops/2019-05-21-gothenburg.md
@@ -48,7 +48,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Tuesday, May 21

--- a/_workshops/2019-05-27-helsinki.md
+++ b/_workshops/2019-05-27-helsinki.md
@@ -49,7 +49,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Monday, May 27

--- a/_workshops/2019-06-03-oslo.md
+++ b/_workshops/2019-06-03-oslo.md
@@ -46,7 +46,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Monday, June 03

--- a/_workshops/2019-06-11-aalborg.md
+++ b/_workshops/2019-06-11-aalborg.md
@@ -49,7 +49,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Tuesday, June 11

--- a/_workshops/2019-10-22-trondheim.md
+++ b/_workshops/2019-10-22-trondheim.md
@@ -49,6 +49,8 @@ software:
     url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
     url: https://coderefinery.github.io/installation/accounts/
+  - title: Troubleshooting
+    url: https://coderefinery.github.io/installation/troubleshooting/
 
 schedule:
   - date: Tuesday, October 22

--- a/_workshops/2019-10-22-trondheim.md
+++ b/_workshops/2019-10-22-trondheim.md
@@ -37,10 +37,10 @@ software:
     url: https://coderefinery.github.io/installation/bash/
   - title: Editor
     url: https://coderefinery.github.io/installation/editors/
-  - title: Git
-    url: https://coderefinery.github.io/installation/git/
   - title: Python
     url: https://coderefinery.github.io/installation/python/
+  - title: Git
+    url: https://coderefinery.github.io/installation/git/
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab

--- a/_workshops/2019-10-22-trondheim.md
+++ b/_workshops/2019-10-22-trondheim.md
@@ -44,11 +44,11 @@ software:
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab
-    url: https://coderefinery.github.io/installation/jupyter
+    url: https://coderefinery.github.io/installation/jupyter/
   - title: Snakemake
-    url: https://coderefinery.github.io/installation/snakemake
+    url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
-    url: https://coderefinery.github.io/installation/accounts
+    url: https://coderefinery.github.io/installation/accounts/
 
 schedule:
   - date: Tuesday, October 22

--- a/_workshops/2019-10-22-trondheim.md
+++ b/_workshops/2019-10-22-trondheim.md
@@ -48,7 +48,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Tuesday, October 22

--- a/_workshops/2019-11-19-stockholm.md
+++ b/_workshops/2019-11-19-stockholm.md
@@ -50,6 +50,8 @@ software:
     url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
     url: https://coderefinery.github.io/installation/accounts/
+  - title: Troubleshooting
+    url: https://coderefinery.github.io/installation/troubleshooting/
 
 schedule:
   - date: Tuesday, November 19

--- a/_workshops/2019-11-19-stockholm.md
+++ b/_workshops/2019-11-19-stockholm.md
@@ -49,7 +49,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Tuesday, November 19

--- a/_workshops/2019-11-19-stockholm.md
+++ b/_workshops/2019-11-19-stockholm.md
@@ -38,10 +38,10 @@ software:
     url: https://coderefinery.github.io/installation/bash/
   - title: Editor
     url: https://coderefinery.github.io/installation/editors/
-  - title: Git
-    url: https://coderefinery.github.io/installation/git/
   - title: Python
     url: https://coderefinery.github.io/installation/python/
+  - title: Git
+    url: https://coderefinery.github.io/installation/git/
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab

--- a/_workshops/2019-11-19-stockholm.md
+++ b/_workshops/2019-11-19-stockholm.md
@@ -45,11 +45,11 @@ software:
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab
-    url: https://coderefinery.github.io/installation/jupyter
+    url: https://coderefinery.github.io/installation/jupyter/
   - title: Snakemake
-    url: https://coderefinery.github.io/installation/snakemake
+    url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
-    url: https://coderefinery.github.io/installation/accounts
+    url: https://coderefinery.github.io/installation/accounts/
 
 schedule:
   - date: Tuesday, November 19

--- a/_workshops/2019-11-26-aarhus.md
+++ b/_workshops/2019-11-26-aarhus.md
@@ -55,6 +55,8 @@ software:
     url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
     url: https://coderefinery.github.io/installation/accounts/
+  - title: Troubleshooting
+    url: https://coderefinery.github.io/installation/troubleshooting/
 
 schedule:
   - date: Tuesday, November 26

--- a/_workshops/2019-11-26-aarhus.md
+++ b/_workshops/2019-11-26-aarhus.md
@@ -54,7 +54,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Tuesday, November 26

--- a/_workshops/2019-11-26-aarhus.md
+++ b/_workshops/2019-11-26-aarhus.md
@@ -50,11 +50,11 @@ software:
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab
-    url: https://coderefinery.github.io/installation/jupyter
+    url: https://coderefinery.github.io/installation/jupyter/
   - title: Snakemake
-    url: https://coderefinery.github.io/installation/snakemake
+    url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
-    url: https://coderefinery.github.io/installation/accounts
+    url: https://coderefinery.github.io/installation/accounts/
 
 schedule:
   - date: Tuesday, November 26

--- a/_workshops/2019-11-26-aarhus.md
+++ b/_workshops/2019-11-26-aarhus.md
@@ -43,10 +43,10 @@ software:
     url: https://coderefinery.github.io/installation/bash/
   - title: Editor
     url: https://coderefinery.github.io/installation/editors/
-  - title: Git
-    url: https://coderefinery.github.io/installation/git/
   - title: Python
     url: https://coderefinery.github.io/installation/python/
+  - title: Git
+    url: https://coderefinery.github.io/installation/git/
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab

--- a/_workshops/2019-12-10-espoo.md
+++ b/_workshops/2019-12-10-espoo.md
@@ -56,6 +56,8 @@ software:
     url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
     url: https://coderefinery.github.io/installation/accounts/
+  - title: Troubleshooting
+    url: https://coderefinery.github.io/installation/troubleshooting/
 
 schedule:
   - date: Tuesday, December 10

--- a/_workshops/2019-12-10-espoo.md
+++ b/_workshops/2019-12-10-espoo.md
@@ -44,10 +44,10 @@ software:
     url: https://coderefinery.github.io/installation/bash/
   - title: Editor
     url: https://coderefinery.github.io/installation/editors/
-  - title: Git
-    url: https://coderefinery.github.io/installation/git/
   - title: Python
     url: https://coderefinery.github.io/installation/python/
+  - title: Git
+    url: https://coderefinery.github.io/installation/git/
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab

--- a/_workshops/2019-12-10-espoo.md
+++ b/_workshops/2019-12-10-espoo.md
@@ -51,11 +51,11 @@ software:
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab
-    url: https://coderefinery.github.io/installation/jupyter
+    url: https://coderefinery.github.io/installation/jupyter/
   - title: Snakemake
-    url: https://coderefinery.github.io/installation/snakemake
+    url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
-    url: https://coderefinery.github.io/installation/accounts
+    url: https://coderefinery.github.io/installation/accounts/
 
 schedule:
   - date: Tuesday, December 10

--- a/_workshops/2019-12-10-espoo.md
+++ b/_workshops/2019-12-10-espoo.md
@@ -55,7 +55,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Tuesday, December 10

--- a/_workshops/template.md
+++ b/_workshops/template.md
@@ -48,6 +48,8 @@ software:
     url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
     url: https://coderefinery.github.io/installation/accounts/
+  - title: Troubleshooting
+    url: https://coderefinery.github.io/installation/troubleshooting/
 
 schedule:
   - date: Tuesday, June 11

--- a/_workshops/template.md
+++ b/_workshops/template.md
@@ -47,7 +47,7 @@ software:
   - title: Snakemake
     url: https://coderefinery.github.io/installation/snakemake
   - title: Accounts
-    url: https://coderefinery.github.io/installation/#accounts
+    url: https://coderefinery.github.io/installation/accounts
 
 schedule:
   - date: Tuesday, June 11

--- a/_workshops/template.md
+++ b/_workshops/template.md
@@ -36,10 +36,10 @@ software:
     url: https://coderefinery.github.io/installation/bash/
   - title: Editor
     url: https://coderefinery.github.io/installation/editors/
-  - title: Git
-    url: https://coderefinery.github.io/installation/git/
   - title: Python
     url: https://coderefinery.github.io/installation/python/
+  - title: Git
+    url: https://coderefinery.github.io/installation/git/
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab

--- a/_workshops/template.md
+++ b/_workshops/template.md
@@ -43,11 +43,11 @@ software:
   - title: (optional) Visual diff tools
     url: https://coderefinery.github.io/installation/difftools/
   - title: Jupyter and JupyterLab
-    url: https://coderefinery.github.io/installation/jupyter
+    url: https://coderefinery.github.io/installation/jupyter/
   - title: Snakemake
-    url: https://coderefinery.github.io/installation/snakemake
+    url: https://coderefinery.github.io/installation/snakemake/
   - title: Accounts
-    url: https://coderefinery.github.io/installation/accounts
+    url: https://coderefinery.github.io/installation/accounts/
 
 schedule:
   - date: Tuesday, June 11


### PR DESCRIPTION
This PR is coupled to https://github.com/coderefinery/installation/pull/85.