### PR TITLE
Link from TTT page to the github material (new link)

### DIFF
--- a/_events/2019-11-04-stockholm.md
+++ b/_events/2019-11-04-stockholm.md
@@ -59,8 +59,12 @@ of new CodeRefinery lessons!
 
 ### Schedule
 
-Lesson material (for each of the items below) can be found at
-https://coderefinery.github.io/instructor-training/
+* Lesson material (for each of the items below) can be found at
+  https://coderefinery.github.io/instructor-training/
+* Each individual lesson can be found at
+  https://coderefinery.org/lessons/
+* CodeRefinery Github can be found at
+  https://github.com/coderefinery/
 
 #### Monday, November 4
 

--- a/_events/2019-11-04-stockholm.md
+++ b/_events/2019-11-04-stockholm.md
@@ -59,6 +59,9 @@ of new CodeRefinery lessons!
 
 ### Schedule
 
+Lesson material (for each of the items below) can be found at
+https://coderefinery.github.io/instructor-training/
+
 #### Monday, November 4
 
 The first day is focused on generalities of teaching and lesson design.


### PR DESCRIPTION
- The CodeRefinery workshop page was missing a link to the actual
  material, this adds it.
- No per-episode links yet, maybe that's not worth doing.
- This is the *new* URL so won't work until the instructor_training
  repo name is changed from "_" to "-".