### PR TITLE
Fix column about info column height with flex

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -464,7 +464,17 @@ csmall2 {
 	font-size: 18px;
 }
 
-
+.row {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display:         flex;
+	flex-wrap: wrap;
+}
+.row > [class*='col-'] {
+	display: flex;
+	flex-direction: column;
+}
 
 
 div.centered


### PR DESCRIPTION
Fixing a bug in the about page that causes the columns to have different heights.

**Current page:**
![image](https://user-images.githubusercontent.com/47524/68370360-fc44e980-0144-11ea-86d4-e4a3db1b260b.png)

---

**After fix:**
![image](https://user-images.githubusercontent.com/47524/68370387-0e268c80-0145-11ea-847d-35a29100c908.png)
