### PR TITLE
Change contents to fit the event 11. Feb.

### DIFF
--- a/_events/2020-02-11-online.md
+++ b/_events/2020-02-11-online.md
@@ -19,14 +19,13 @@ CodeRefinery is organizing a one day online "open house" dedicated to discussion
 
 Following up our successful first CodeRefinery Open House, we will have our second online Open house!
 
-The idea behind this event is to bring together people who are interesting in
-contributing to [CodeRefinery training material](https://coderefinery.org/lessons/).
+The idea behind this event is to work together on revising and improving [CodeRefinery.org](https://coderefinery.org/). Issues are filed and we are taking what each of us wants to work on. Input for the further improvement are all welcome!
 
-Anyone who would like to contribute, learn how to contribute to the CodeRefinery training material is very welcome to join.
+Anyone who would like to contribute, learn how to contribute to the CodeRefinery.org is very welcome to join.
 
 We first meet online at 9:00 am (UTC + 1) via Hangout and then work on CodeRefinery training material. During the day, we will coordinate the work through our [zulip](https://coderefinery.zulipchat.com/) channel with possibilities to further discuss via Hangout if necessary.
 
-Shared document for live editing: [https://hackmd.io/1Sso1UFMTXKihv1sedsTIA](https://hackmd.io/1Sso1UFMTXKihv1sedsTIA). Please note that this document contains information about all our Open House event and is not specific to this one.
+Shared document for live editing on HackMD is to be provided soon. Please note that this document will be archived in our Open House event repository.
 
 We conclude the day around 4:00pm (UTC + 1) by writing a short blog/summary in a shared document.
 


### PR DESCRIPTION
Changed contents copied from the Open House event in December to fit the purpose of this event. Still needs URL for HackMD and repository to be archived.