### PR TITLE
about/hubs: Add more hubs

### DIFF
--- a/about/hubs.md
+++ b/about/hubs.md
@@ -12,8 +12,15 @@ committed to organizing a workshop at least once a year, and then.
 ## Current hubs
 
 
-* Aalto University, Helsinki region, sponsored by [Aalto Scientific Computing](https://scicomp.aalto.fi/)
-* KTH, Stockholm, sponsored by [PDC](https://www.pdc.kth.se/)
+* Aalto University, Helsinki region, sponsored by [Aalto Scientific
+  Computing](https://scicomp.aalto.fi/).
+  Workshops every May (Helsinki)/December (Aalto) in partnership with
+  the University of Helsinki.
+* KTH, Stockholm, sponsored by [PDC](https://www.pdc.kth.se/).
+  Workshops every March-April and October-November.
+* NTNU, Trondheim, sponsored by ??.  Workshops every February and November.
+* University of Oslo, sponsored by ??.  Workshops every June (and
+  possibly more).
 
 ## Become a hub
 


### PR DESCRIPTION
- Hub organizers should indicate the sponsors and fill in any missing details