### PR TITLE
MD files for different parts of the front page

### DIFF
--- a/front-menu-lesson.md
+++ b/front-menu-lesson.md
@@ -1,0 +1,6 @@
+---
+layout: 
+include: 
+title: Lesson materials
+---
+We develop and maintain training material on software best practices for researchers that already write code. Our material addresses all academic disciplines and tries to be as programming language-independent as possible.

--- a/front-menu-repository.md
+++ b/front-menu-repository.md
@@ -1,0 +1,6 @@
+---
+layout: 
+include: 
+title: Code Repository Hosting
+---
+Our code repository hosting service is open and free for all researchers based in Nordic universities and research institutes. Please contact us if you would like to use these services.

--- a/front-menu-training.md
+++ b/front-menu-training.md
@@ -1,0 +1,7 @@
+---
+layout: 
+include: 
+title: Training opportunities
+---
+ 
+We offer training opportunities to researchers from Nordic research groups and projects to learn basic-to-advanced research computing skills and become confident in using state-of-the-art tools and practices from modern collaborative software engineering.

--- a/front-top.md
+++ b/front-top.md
@@ -1,0 +1,6 @@
+---
+layout:  
+---
+Training and e-Infrastructure for Research Software Development
+
+<!--- We are working with students, researchers, Research Software Engineers from all disciplines and national e-infrastructure partners to advance FAIRness of Software management and development practices so that research groups can collaboratively develop, review, discuss, test, share and reuse their codes. --->


### PR DESCRIPTION
Related to #343, I made separate md files for different parts of the front page as followings:

- Top (concise description about CR)
- Concise descriptions of the 3 main services

The contents and front matter should be modified accordingly.