### PR TITLE
add event page for open house on april 24

### DIFF
--- a/_events/2020-04-24-online.md
+++ b/_events/2020-04-24-online.md
@@ -1,0 +1,45 @@
+---
+layout: master
+include: content
+permalink: /events/2020-04-24-online/
+published_date: 2020-04-23
+city: Open house (work on blog posts)
+dates: March 24, 2020
+title: Come and join us for our online Open House
+---
+
+<img src="/assets/img/coderefinery_openhouse.png" alt="CodeRefinery open house" style="width:550px">
+
+## April 24, 2020
+
+### Welcome to the CodeRefinery Open House where we collaboratively work on **writing newsletter articles and blog posts**!
+
+CodeRefinery is organizing a one day online "open house" dedicated to
+collaboratively writing up blog posts which have been in 
+the pipeline for some time and which will be published in the next 
+CodeRefinery newsletter.
+
+Tentative list of articles:
+- Online lessons, what we're working on, how we'll be delivering online workshops
+- Merge vs rebase
+- Nordic-RSE conference
+- NordicHPC tools
+
+Anyone who would like to contribute to these articles or suggests new
+topics is welcome to join!
+
+We will collect notes in a [shared
+document](https://hackmd.io/@doFoQYKqR623RI-YyXvmew/HJGgb_9VL).
+Please note that this document will be archived in our [Open House
+event repository](https://github.com/coderefinery/open-house).
+
+We first meet online at 9:00 am (UTC+1) via video (connection link
+will be shared in our [shared
+document](https://hackmd.io/46XkhCr5T4yahKprL6N01A) and then work on
+the instructor training material. During the day, we will coordinate
+the work through our [Zulip chat](https://coderefinery.zulipchat.com)
+with possibilities to further discuss via video if necessary.
+
+We conclude the day around 4:00 pm (UTC+1) by writing a short
+/summary in our [shared
+document](https://hackmd.io/46XkhCr5T4yahKprL6N01A).


### PR DESCRIPTION
this is to get the event page up asap. Possibly to be followed up by a new structure on upcoming-workshops page