### PR TITLE
add Gemfile with github-pages environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
I learned that this is the more proper way:
https://github.com/bast/til/blob/master/documentation/jekyll-bundler.md

... compared to `jekyll serve` which I was using earlier. Advantage is that you then see locally precisely what you will see on GH pages.