### PR TITLE
Link install instructions from lessons page

### DIFF
--- a/lessons.md
+++ b/lessons.md
@@ -32,6 +32,7 @@ community.
   - [Integrated development environments](https://coderefinery.github.io/IDEs/)
   - [Mixed Martial Arts: Interfacing Fortran, C, C++, and Python](https://coderefinery.github.io/mma/)
   - [CodeRefinery manuals, our guides and hints on running CodeRefinery](https://github.com/coderefinery/manuals)
+  - [Installation instructions](https://coderefinery.github.io/installation/) (not a lesson, see your workshop page for which ones are actually needed for you)
 
 
 ### License


### PR DESCRIPTION
- It might be good to make these more findable - at least I used to
  have to find a random workshop, then navigate to here.  (Now I just
  know the URL).
- To check: On the other hand, people might get confused and install
  something they don't need if they find the installation instructions
  from this link, so it's reasonable to leave this out as well.