### PR TITLE
_includes/upcoming-workshops: Link the online workshop

### DIFF
--- a/_includes/upcoming-workshops.html
+++ b/_includes/upcoming-workshops.html
@@ -62,8 +62,10 @@
 
     <p>
       We had to postpone few workshops due to COVID-19. We have informed all
-      registrants and will post new dates as soon as possible. In parallel we are
-      <b>preparing for providing courses online</b> and will post dates soon.
+      registrants and will post new dates as soon as possible. In
+      parallel we have prepared several other online events, such as the
+      <a href="https://coderefinery.github.io/2020-05-25-online/">large
+      online workshop 25.may-4.june</a> which is open to everyone.
     </p>
 
     <ul>


### PR DESCRIPTION
- The "postponed" message didn't have a link to the online workshops
  we eventually prepared.  Even though this is late, we may as well
  provide a message for future browsers (otherwise someone coming to
  the site won't see it).
- To check: should jekyll have absolute URLs?  Is syntax OK?