### PR TITLE
Added CarpentryCon2020 panel session

### DIFF
--- a/about/project.md
+++ b/about/project.md
@@ -152,7 +152,8 @@ hesitate to [get in touch](/get-involved/)!
 
 ## Presentations
 
-- [Lightning talk at CarpentryConnect 2020, (Sabry Razick)](https://2020.carpentrycon.org/schedule/) -
+- [Panel session at CarpentryCon 2020, (Naoe Tatara, Radovan Bast, Richard Darst, Anne Fouilloux, Petri Jehkonen, Matúš Kalaš, Samantha Wittke)](https://2020.carpentrycon.org/schedule/#session-32) - [Mega CodeRefinery online workshop - How to scale up online workshop to reach 100 learners?](https://cicero.xyz/v3/remark/0.14.0/github.com/coderefinery/carpentrycon-2020/master/slides.md/#1)
+- [Lightning talk at CarpentryCon 2020, (Sabry Razick)](https://2020.carpentrycon.org/schedule/) -
   [Carpentries next level - CodeRefinery model](https://sabryr.github.io/HPC-Carpentry-talk/)
 - [Lightning talk at CarpentryConnect 2019, Manchester (Radovan Bast)](https://software.ac.uk/ccmcr19/programme/posters-lightning-talks)
 - ["Coding like it's 1969", Toulouse, April 2019 (Radovan Bast)](https://cicero.xyz/v3/remark/0.14.0/github.com/bast/talk-coding-like-1969/master/talk.md/)


### PR DESCRIPTION
Added info about our presentation at CarpentryCon 2020 and corrected text to link to Sabry's lightning talk from CarpentryConnect to CapentryCon.