### PR TITLE
Add HPC instructor training as an upcoming workshop

### DIFF
--- a/_workshops/2020-11-02-online.md
+++ b/_workshops/2020-11-02-online.md
@@ -1,7 +1,8 @@
 ---
 permalink: https://coderefinery.github.io/2020-11-02-instructor-training/
-city: Online workshop
+city: Online workshop for [FocusCoE](https://www.hpccoe.eu/index.php/about/) members
 dates: November 02-03 and 09, 2020
 published_date: 2020-10-25
+
 participants: 
 ---

--- a/_workshops/2020-11-02-online.md
+++ b/_workshops/2020-11-02-online.md
@@ -1,0 +1,7 @@
+---
+permalink: https://coderefinery.github.io/2020-11-02-instructor-training/
+city: Online workshop
+dates: November 02-03 and 09, 2020
+published_date: 2020-10-25
+participants: 
+---


### PR DESCRIPTION
Add HPC instructor training as an upcoming workshop, by including 2020-11-02-online.md in _workshops