### PR TITLE
lessons: Add a list of lessons by others in the CodeRefinery community

### DIFF
--- a/lessons.md
+++ b/lessons.md
@@ -36,6 +36,22 @@ community.
   - [CodeRefinery manuals, our guides and hints on running CodeRefinery](https://coderefinery.github.io/manuals/)
   - [Installation instructions](https://coderefinery.github.io/installation/) (not a lesson, see your workshop page for which ones are actually needed for you)
 
+Other lessons by the CodeRefinery community.  You can expect these to
+be open-source, reusable, in a git repository, and with a community
+you can join and give contributions to:
+
+- [Python for Scientific
+  Computing](https://aaltoscicomp.github.io/python-for-scicomp/), by
+  Aalto Scientific Computing, UiO, UiT, KTH.  Not a basic Python
+  course, but taking your from basic programming to the tools needed
+  for scientific computing.
+- [Linux shell
+  tutorial](https://scicomp.aalto.fi/training/linux-shell-tutorial/).
+  By Aalto Scientific Computing, level: intermediate, covers basics
+  but focus on scripting.
+
+
+
 ### Teach our lessons
 
 All of our material is open source and collaboratively developed: you


### PR DESCRIPTION
- If we want a community and visibility, we should have a list of these
- I have seeded the list with two of our couses we might want to
  share.  Though linux-shell-tutorial should be split into another
  repo, or removed (and if it stays, it needs some quality control to
  make sure the audience and purpose is clear).
- Other things that could possibly be added:
  - https://enccs.github.io/intermediate-mpi/ @kthw
  - HPC Carpentry @sabryr
  - I'm sure a lot more that I don't remember right now
- I consider this a sort of temporary location, it can be moved
  somewhere better later.
- Review:
  - We should consider if this is a good idea, or even in the right
    location.
  - Add a few other courses to round it out (not make it aalto-centric)