### PR TITLE
Revert ".github/workflows/build: Fix builds in forks"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ env:
   ZOLA_VERSION: "0.13.0"
   MAIN_BRANCH: "main"
   TARGET_BRANCH: "gh-pages"
-  #DEPLOY_ORGANIZATION: ""
   #CNAME: xxx   # or make a CNAME in the root
 
 on:
@@ -41,7 +40,6 @@ jobs:
     - name: debugging info
       run: |
         zola --version
-        echo github.ref: ${{ github.ref }}
     - name: Generate HTML
       run: zola build
     # Add CNAME, either (first one used)
@@ -56,8 +54,8 @@ jobs:
         if [ -n ${{ env.CNAME }} ] ; then
             echo -n ${{ env.CNAME }} > public/CNAME
         fi
-    - name: Deploy to gh-pages
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/${{ env.MAIN_BRANCH }}' }}
+    - name: Commit and push to target branch
+      if: github.ref == 'refs/heads/${{ env.MAIN_BRANCH }}'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit f3e120990652d12e9e4af741f0d2b62c654c2d9f.

Reverting this because it does not rebuild gh-pages on upstream.
This needs to be tested better first before we generalize this to forks.