### PR TITLE
add community events macro and details

### DIFF
--- a/content/about/meeting-minutes.md
+++ b/content/about/meeting-minutes.md
@@ -18,4 +18,4 @@ and deliverables.
 Scope: All topics involving community onboarding, workshop scheduling,
 governance, and roadmap.
 
-Soon we will publish an agenda and meeting minutes here.
+{{ comunity() }}

--- a/content/workshops/community-calls.json
+++ b/content/workshops/community-calls.json
@@ -1,13 +1,16 @@
 {
     "events": [
         {
-            "topic": " Feedback and updates round",
+            "name": "Community Call: Feedback and updates round (Online)",
             "website": "https://hackmd.io/@coderefinery/H1XUL1Hiu",
-            "zoom": "",
             "start_date": "2021-08-09",
             "end_date": "2021-08-09",
             "host": [
                 "Samantha Wittke"
+            ],
+            "expert_helpers": [
+            ],
+            "helpers": [
             ],
             "invited": "All exercise leaders, helpers, exeprt helpers and instructors of 2020/21 CodeRefinery workshops"
         }

--- a/content/workshops/community.json
+++ b/content/workshops/community.json
@@ -1,0 +1,15 @@
+{
+    "events": [
+        {
+            "topic": " Feedback and updates round",
+            "website": "https://hackmd.io/@coderefinery/H1XUL1Hiu",
+            "zoom": "",
+            "start_date": "2021-08-09",
+            "end_date": "2021-08-09",
+            "host": [
+                "Samantha Wittke"
+            ],
+            "invited": "All exercise leaders, helpers, exeprt helpers and instructors of 2020/21 CodeRefinery workshops"
+        }
+    ]
+}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -181,3 +181,52 @@
     </table>
   </div>
 {% endmacro table %}
+
+
+{% macro list_of_community_calls(data, linebreak) %}
+  {% set now_unix_timestamp = now() | date(format="%s") | int %}
+  {% set data_length = data.events | length %}
+  {% if data_length == 0 %}
+    <p> No Community Calls</p>
+  {% endif %}
+  <ul>
+    {% for event in data.events %}
+    {% set event_unix_timestamp = event.start_date | date(format="%s") | int %}
+    {% set in_future = now_unix_timestamp < event_unix_timestamp %}
+   
+    <li>
+      {% if event.website %}
+        <a href="{{ event.website }}" target=_blank>{{ event.topic }}</a>
+      {% else %}
+        {{ event.topic }}
+      {% endif %}
+      <div style="color: #b0b0b0; display: inline;">
+      {% if linebreak %}
+        <br>
+      {% else %}
+        &nbsp;
+      {% endif %}
+      {% if event.start_date == event.end_date %}
+        {{ event.start_date | date(format="%b %_d, %Y") }}
+      {% else %}
+        {{ event.start_date | date(format="%b %_d") }}
+        -
+        {{ event.end_date | date(format="%b %_d, %Y") }}
+      {% endif %}
+      {% if in_future%}
+      <b style="color: #3d3d3d;">(Upcoming Event)</b>
+      {% endif %}
+      <p>
+        Invited: {{ event.invited }}
+      </p>
+      {% if event.zoom %}
+      <p>
+        Zoom: <a href="{{ event.zoom }}" target=_blank>{{ event.zoom }}</a>
+      </p>
+      {% endif %}
+      </div>
+    </li>
+    
+    {% endfor %}
+  </ul>
+{% endmacro list_of_community_calls %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -196,9 +196,9 @@
    
     <li>
       {% if event.website %}
-        <a href="{{ event.website }}" target=_blank>{{ event.topic }}</a>
+        <a href="{{ event.website }}" target=_blank>{{ event.name }}</a>
       {% else %}
-        {{ event.topic }}
+        {{ event.name }}
       {% endif %}
       <div style="color: #b0b0b0; display: inline;">
       {% if linebreak %}
@@ -219,11 +219,6 @@
       <p>
         Invited: {{ event.invited }}
       </p>
-      {% if event.zoom %}
-      <p>
-        Zoom: <a href="{{ event.zoom }}" target=_blank>{{ event.zoom }}</a>
-      </p>
-      {% endif %}
       </div>
     </li>
     

--- a/templates/shortcodes/comunity.html
+++ b/templates/shortcodes/comunity.html
@@ -1,0 +1,8 @@
+{% import "macros.html" as macros %}
+
+<div class="row">
+    <div class="col-md-12">
+        {% set data = load_data(path="content/workshops/community.json") %}
+        {{ macros::list_of_community_calls(data=data, linebreak=false) }}
+    </div>
+</div>

--- a/templates/shortcodes/comunity.html
+++ b/templates/shortcodes/comunity.html
@@ -2,7 +2,7 @@
 
 <div class="row">
     <div class="col-md-12">
-        {% set data = load_data(path="content/workshops/community.json") %}
+        {% set data = load_data(path="content/workshops/community-calls.json") %}
         {{ macros::list_of_community_calls(data=data, linebreak=false) }}
     </div>
 </div>

--- a/templates/shortcodes/upcoming.html
+++ b/templates/shortcodes/upcoming.html
@@ -8,5 +8,7 @@
     {{ macros::list_of_events(data=data, linebreak=false, show_only_future=true) }}
     {% set data = load_data(path="content/workshops/other.json") %}
     {{ macros::list_of_events(data=data, linebreak=false, show_only_future=true) }}
+    {% set data = load_data(path="content/workshops/community-calls.json") %}
+    {{ macros::list_of_events(data=data, linebreak=false, show_only_future=true) }}
   </div>
 </div>


### PR DESCRIPTION
- reuse the existing format of the workshops and create a similar macro to add community calls
- if the community calls are upcoming a label will be shown

I thought of adding it to workshop/events but that place did not seem ok. Suggestions are welcomed.
Was not sure to add zoom link with passwd and all.