### PR TITLE
adjust main page columns to same height

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -27,6 +27,10 @@ footer .social:hover{
   text-decoration: none;
 }
 
+.panel .top-buffer {
+    flex-grow: 1;
+}
+
 p {
   padding: 0;
   margin-bottom: 12px;
@@ -45,6 +49,10 @@ div.panel {
   column-gap: 10px;
   background-color: #F3F6F9;
   flex: 1;
+  margin: 10px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 1px 2px 2px #cfdcea;
 }
 
 .button_more {
@@ -59,6 +67,12 @@ div.panel {
   margin: 4px 2px;
   cursor: pointer;
   border-radius: 10px;
+}
+
+.button_more:hover{
+  color: white;
+  background-color: #5996d3;
+  text-decoration: none;
 }
 
 img {

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,7 +40,6 @@
   <div class="row top-buffer">
 
     <!-- box "training opportunities" -->
-    <div class="col-md-3">
       <div class="panel">
         <a href="/workshops/about/">
           {% set classroom = resize_image(path="img/classroom.png", width=200, op="fit_width") %}
@@ -58,10 +57,8 @@
         </div>
         <a class="button_more" href="/workshops/about/">More ›</a></p>
       </div>
-    </div>
 
     <!-- box "lesson materials" -->
-    <div class="col-md-3">
       <div class="panel">
         <a href="/lessons/">
           {% set wordcloud = resize_image(path="img/wordcloud.png", width=200, op="fit_width") %}
@@ -79,10 +76,8 @@
         </div>
         <a class="button_more" href="/lessons/">More ›</a></p>
       </div>
-    </div>
 
     <!-- box "code repository hosting" -->
-    <div class="col-md-3">
       <div class="panel">
         <a href="/repository/">
           {% set terminal = resize_image(path="img/terminal.png", width=200, op="fit_width") %}
@@ -99,14 +94,12 @@
         </div>
         <a class="button_more" href="/repository/">More ›</a></p>
       </div>
-    </div>
 
     <!-- box "research software hour" -->
-    <div class="col-md-3">
       <div class="panel">
         <a href="https://researchsoftwarehour.github.io/">
           <img src="https://raw.githubusercontent.com/ResearchSoftwareHour/researchsoftwarehour.github.io/main/static/img/logo-hashbang.png"
-               style="width: 150px"
+               style="width: 150px; max-height: 122.55px;"
                alt="ResearchSoftwareHour logo"/>
         </a>
         <div class="top-buffer">
@@ -121,7 +114,7 @@
         </div>
         <a class="button_more" href="https://researchsoftwarehour.github.io/">More ›</a></p>
       </div>
-    </div>
+
 
   </div><!-- row -->
 


### PR DESCRIPTION
This is based on #564 not to interfere with how new images are getting rendered
It makes the div on the home page same length

Before:
![image](https://user-images.githubusercontent.com/47524/129305044-a55c1f58-3d98-41da-bbd4-58b027fefbf2.png)


--- 

After:

![image](https://user-images.githubusercontent.com/47524/129305016-8382561b-cdb7-4a72-9c83-49173ff2d7d0.png)
