### PR TITLE
content/about/hubs: Change #kickstart-cr to #coderefinery

### DIFF
--- a/content/about/hubs.md
+++ b/content/about/hubs.md
@@ -21,7 +21,7 @@ We need your support to spin-off and register CodeRefinery as a foundation in on
 
 CodeRefinery is working on setting up a kickstart campaign to raise the necessary funds.
 
-If you are interested, get in touch with us on [https://coderefinery.zulipchat.com](https://coderefinery.zulipchat.com) in #kickstart-cr stream. 
+If you are interested, get in touch with us on [https://coderefinery.zulipchat.com](https://coderefinery.zulipchat.com) in #coderefinery stream. 
 
 ## CodeRefinery membership
 


### PR DESCRIPTION
- I think there was some discussion about this (I didn't look it up),
  but I think it is better to keep things in fewer streams, unless
  they are high-volume or about a very different subset of people.
- Review: is this a good idea?  should we get bigger agreement?
