### PR TITLE
templates/base: Add HTML link rel="alternate" type="...atom+xml"

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,9 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="shortcut icon" href="/img/favicon.ico">
+    {% block rss %}
+      <link rel="alternate" type="application/atom+xml" title="CodeRefinery" href="{{ get_url(path="atom.xml", trailing_slash=false) }}" />
+    {% endblock %}
 
     {% if page.title %}
       <title>CodeRefinery - {{ page.title }}</title>


### PR DESCRIPTION
- This should make the atom feed auto-discoverable by browsers and so
  on.
- Untested
- Search "html meta atom feed" to find some various examples of this -
  at least that is how I found it.
- Review: general check, maybe merge and see if it works?
