### PR TITLE
link fix for community call info

### DIFF
--- a/content/workshops/upcoming.md
+++ b/content/workshops/upcoming.md
@@ -19,7 +19,7 @@ is important for RSS feed. -->
 
 ### Community calls
 
-More details on [this page](/about/meeting-minutes/)
+More details on [this page](/about/community-call/)
 
 
 ### Past workshops and events


### PR DESCRIPTION
I was looking for old times of the community call and noticed that this link was broken, maybe there needs to be also a word about that community calls are planned to continue in 2022?