### PR TITLE
Announce community call and move staff meetings to archive/history

### DIFF
--- a/content/organization/meeting-minutes.md
+++ b/content/organization/meeting-minutes.md
@@ -15,7 +15,7 @@ and deliverables.
 
 ## Community calls
 
-Held on a montly intervall on Mondays at 14 CET. **Next meeting is Monday, January 31, 2021, 14-15 CET/ 15-16 EET**.
+Held on a monthly interval on Mondays at 14 CET. **Next meeting is Monday, January 31, 2021, 14-15 CET/ 15-16 EET**.
 
 Scope: All topics involving community onboarding, workshop scheduling,
 governance, and roadmap.

--- a/content/organization/meeting-minutes.md
+++ b/content/organization/meeting-minutes.md
@@ -2,17 +2,6 @@
 title = "Meeting minutes"
 +++
 
-## Staff meeting minutes
-
-Scope: Administrative tasks involving paid staff such as generation of reports
-and deliverables.
-
-- [Latest meeting minutes](/about/staff-meetings/)
-- How we prepare and archive minutes: On top of
-  <https://hackmd.io/@coderefinery/staff-meeting>
-- [Archive of past meetings](https://github.com/coderefinery/coderefinery.org/commits/main/content/about/staff-meetings.md)
-
-
 ## Community calls
 
 Held on a monthly interval on Mondays at 14 CET. **Next meeting is Monday, January 31, 2022,** 14-15 CET/ 15-16 EET
@@ -23,7 +12,7 @@ governance, and roadmap.
 - [Next meeting agenda and connection details](https://hackmd.io/@coderefinery/community-call)
 
 
-#### Archive of past meetings
+### Archive of past community calls
 
 - [Theme: Briefing on Nov 2021 NeIC meeting and Jan 2022 NeIC AHM meeting](https://github.com/coderefinery/coderefinery.org/blob/38f1273/content/about/community-call.md)
 - [Theme: Workshop planning for 2022 (2021-10-04)](https://github.com/coderefinery/coderefinery.org/blob/6f0afb3/content/about/community-call.md)
@@ -31,3 +20,14 @@ governance, and roadmap.
 - [Theme: CodeRefinery way forward (2021-09-06)](https://github.com/coderefinery/coderefinery.org/blob/afb8b4f/content/about/community-call.md)
 - [Theme: Get to know CodeRefinery (2021-08-23)](https://github.com/coderefinery/coderefinery.org/blob/a47cb40/content/about/community-call.md)
 - [Theme: Feedback and updates round (2021-08-09)](https://github.com/coderefinery/coderefinery.org/blob/7b65d3a/content/about/community-call.md)
+
+
+### Archive of past staff meetings
+
+These were meetings about administrative tasks such as generation of reports
+and deliverables, involving paid staff.  In Autumn 2021, with the end of phase
+2 of the project, we dropped the distinction between "staff" and "non-staff"
+and dropped the separation between staff meetings and community calls and
+started to focus on community calls.
+
+- [Archive of past meetings](https://github.com/coderefinery/coderefinery.org/commits/main/content/about/staff-meetings.md)

--- a/content/organization/meeting-minutes.md
+++ b/content/organization/meeting-minutes.md
@@ -15,7 +15,7 @@ and deliverables.
 
 ## Community calls
 
-Held on a monthly interval on Mondays at 14 CET. **Next meeting is Monday, January 31, 2021, 14-15 CET/ 15-16 EET**.
+Held on a monthly interval on Mondays at 14 CET. **Next meeting is Monday, January 31, 2022,** 14-15 CET/ 15-16 EET
 
 Scope: All topics involving community onboarding, workshop scheduling,
 governance, and roadmap.

--- a/content/organization/meeting-minutes.md
+++ b/content/organization/meeting-minutes.md
@@ -15,16 +15,15 @@ and deliverables.
 
 ## Community calls
 
-Held on a montly intervall on Mondays at 14 CET. Next meeting is Mon 22 Nov 2021, 14-15 CET/ 15-16 EET.
+Held on a montly intervall on Mondays at 14 CET. **Next meeting is Monday, January 31, 2021, 14-15 CET/ 15-16 EET**.
 
 Scope: All topics involving community onboarding, workshop scheduling,
 governance, and roadmap.
 
 - [Next meeting agenda and connection details](https://hackmd.io/@coderefinery/community-call)
-- [Latest meeting minutes](/about/community-call/)
 
 
-### Archive of past meetings
+#### Archive of past meetings
 
 - [Theme: Briefing on Nov 2021 NeIC meeting and Jan 2022 NeIC AHM meeting](https://github.com/coderefinery/coderefinery.org/blob/38f1273/content/about/community-call.md)
 - [Theme: Workshop planning for 2022 (2021-10-04)](https://github.com/coderefinery/coderefinery.org/blob/6f0afb3/content/about/community-call.md)


### PR DESCRIPTION
- The HackMD for the community call as well as connection details have been updated