### PR TITLE
mv contact to own page

### DIFF
--- a/content/about/project.md
+++ b/content/about/project.md
@@ -31,7 +31,7 @@ namely in Iceland, Denmark, Norway, Sweden, Finland and Estonia.
 
 Our [code repository hosting service](/repository/) is open and free for all
 researchers based in Nordic universities and research institutes. Please
-[contact us](/get-involved/#contact-us) if you would like to use these services.
+[contact us](/organization/contact/) if you would like to use these services.
 
 
 ## Training opportunities
@@ -53,7 +53,7 @@ robust software.  These workshops are based on [training material](/lessons/)
 we develop and maintain.
 * **Online workshops** - Since April 2020, we offer both "full-package" workshops by 6 half-days over 2 weeks with the same contents as 2-day in-person workshop ([training material](/lessons/)) and shorter workshops focusing on one or a limited number of lessons. 
 * **Requesting a workshop** - Would you like to host a CodeRefinery workshop at your home institution?
-**[Get in touch](/get-involved/#contact-us) if this sounds interesting!**
+**[Get in touch](/organization/contact/) if this sounds interesting!**
 Note that even though CodeRefinery is a Nordic project, we are interested in giving workshops
 also outside the Nordics and are able to do so provided that funding for travel and
 accommodation can be covered.

--- a/content/organization/contact.md
+++ b/content/organization/contact.md
@@ -1,0 +1,29 @@
++++
+title = "Contact us"
++++
+
+### Zulip
+
+We use [Zulip](https://zulipchat.com) to discuss within our team and community.
+We discuss in the open and you can join us on
+<https://coderefinery.zulipchat.com>: you can listen in, follow
+certain threads, participate, and influence. [Learn how it
+works](https://coderefinery.github.io/manuals/chat/).
+
+
+### Support line
+
+To ask questions about workshops or services or to report issues:
+[support@coderefinery.org](mailto:support@coderefinery.org)
+
+
+### Newsletter
+
+You can subscribe to the CodeRefinery newsletter
+[here](https://tinyletter.com/coderefinery).
+
+
+### Twitter
+
+If you like what we do, please reach out:
+[@coderefine](https://twitter.com/coderefine)

--- a/content/organization/get-involved.md
+++ b/content/organization/get-involved.md
@@ -84,7 +84,7 @@ would like to attend another one to refresh your memory and share your own
 knowledge? Or do you already have a solid background in research software
 engineering and would like to meet like-minded people in a friendly
 environment? Join a Carpentry or CodeRefinery workshop as a helper! [Get in
-touch](/get-involved/#contact-us) and let us know which workshop you would like
+touch](/organization/contact/) and let us know which workshop you would like
 to join. For more information about what a helper is supposed to do, please
 refer [Helper’s
 guide](https://coderefinery.github.io/manuals/helping-and-teaching/)
@@ -117,7 +117,7 @@ All our [lessons](/lessons/) are [on GitHub](https://github.com/coderefinery). C
 to the lesson material are highly welcome! The best way to contribute is via
 the forking-pull request workflow. See our lesson on [collaborative version
 control](https://coderefinery.github.io/git-collaborative/02-distributed/) for
-an overview of how this works. You can also [contact us](/get-involved/#contact-us) via other
+an overview of how this works. You can also [contact us](/organization/contact/) via other
 channels.
 
 
@@ -143,33 +143,3 @@ seeking for partnerships to stay sustainable long-term.
 
 Please take a look at [training hubs
 page](https://coderefinery.org/about/hubs/) for more information on CodeRefinery Membership options.
-
----
-
-## Contact us
-
-### Zulip
-
-We use [Zulip](https://zulipchat.com) to discuss within our team and community.
-We discuss in the open and you can join us on
-<https://coderefinery.zulipchat.com>: you can listen in, follow
-certain threads, participate, and influence. [Learn how it
-works](https://coderefinery.github.io/manuals/chat/).
-
-
-### Support line
-
-To ask questions about workshops or services or to report issues:
-[support@coderefinery.org](mailto:support@coderefinery.org)
-
-
-### Newsletter
-
-You can subscribe to the CodeRefinery newsletter
-[here](https://tinyletter.com/coderefinery).
-
-
-### Twitter
-
-If you like what we do, please reach out:
-[@coderefine](https://twitter.com/coderefine)

--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -165,7 +165,7 @@ We obtain the following data anonymously and voluntarily from users.
 
 - You have the right to register to a workshop anonymously.
 - If you want to be removed from announcement lists, please [let us
-  know](/get-involved/#contact-us).
+  know](/organization/contact/).
 - Workshop registration can be canceled before and removed, otherwise we keep
   it for sending a request to answer pre-/post-workshop survey.
 - If you want access to your data or to be removed, email us from the address
@@ -174,5 +174,5 @@ We obtain the following data anonymously and voluntarily from users.
 
 ## Questions/concerns?
 
-- If you believe something is wrong, please [let us know](/get-involved/#contact-us).
+- If you believe something is wrong, please [let us know](/organization/contact/).
 - You have the right to lodge complaint with supervisory authority.

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,6 +78,7 @@
                 <a class="dropdown-item" href="{{ get_url(path="/organization/contributors/") | safe }}">Instructors and helpers</a>
                 <a class="dropdown-item" href="{{ get_url(path="/organization/hubs/") | safe }}">Training hubs</a>
                 <a class="dropdown-item" href="{{ get_url(path="/organization/meetings/") | safe }}">Meetings</a>
+                <a class="dropdown-item" href="{{ get_url(path="/organization/contact/") | safe }}">Contact</a>
 	          </div>
             </li>
 


### PR DESCRIPTION
- de-clutters "get involved" a bit
- fixes broken links to "contact us"