### PR TITLE
templates/index: Add direct link to upcoming workshop

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -64,10 +64,9 @@
   <div class="row">
     <div class="col-md-12">
       <h3>
-        <a href="/workshops/upcoming/" target="_blank">Upcoming workshops and events</a>:
-        March 22-24 and 29-31, 2022,
-        and
-        September 20-22 and 27-29, 2022.
+        Upcoming workshops and events:
+        <a href="https://coderefinery.github.io/2022-09-20-workshop/"> September 20-22 and 27-29, 2022</a>
+        and <a href="/workshops/upcoming/" target="_blank">the full list</a>.
       </h3>
     </div>
   </div><!-- row -->


### PR DESCRIPTION
* Needs to be linked from the front page

* Also change the format of the link to the main list, make the main
  list more explitit.  The previous format wasn't quite clear to my
  mind, is this new format good though?

* Review: automerge
