### PR TITLE
adding a quick link to left hand side "news"

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
       <h3>
         <a href="https://coderefinery.github.io/2022-09-20-workshop/">Register for the September 2022 CodeRefinery workshop!</a>
         <br>
+        <br>
         We got
         <a href="https://neic.no/news/2021/10/01/2021-open-call-results/" target="_blank">new funding</a>
         until 2025!

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,8 @@
            alt="CodeRefinery logo" class="pull-left mr-2"/>
 
       <h3>
+        <a href="https://coderefinery.github.io/2022-09-20-workshop/">Register for the September 2022 CodeRefinery workshop!</a>
+        <br>
         We got
         <a href="https://neic.no/news/2021/10/01/2021-open-call-results/" target="_blank">new funding</a>
         until 2025!


### PR DESCRIPTION
This is a "lift-up" for the September workshop so that it is immediately visible when loading the website. Please note that I did not render nor test the HTML (apologies), so maybe an extra "br" might be needed.