### PR TITLE
templates/index: Add a link to the past workshop schedule for reading

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
            alt="CodeRefinery logo" class="pull-left mr-2"/>
 
       <h3>
-        <a href="https://www.youtube.com/watch?v=GHlF1nGfz7g&list=PLpLblYHCzJACqaFsfQiCWp0Wqy6qG4iau">Watch the recordings from September 2022 CodeRefinery workshop!</a>
+        <a href="https://www.youtube.com/watch?v=GHlF1nGfz7g&list=PLpLblYHCzJACqaFsfQiCWp0Wqy6qG4iau">Watch the recordings from September 2022 CodeRefinery workshop!</a> or <a href="https://coderefinery.github.io/2022-09-20-workshop/schedule/">check out the lessons themselves</a>
         <br>
         <br>
         We got


### PR DESCRIPTION
- There was a link to the videos, but perhaps linking to the schedule,
  that has links to all the actual material, would be useful, too?
- I think this may be better than linking to /lessons/, since there
  are a lot of other secondary lessons there which might make it hard
  to see the main point.  And this makes it seem like one is there,
  maybe?
- Review: consider carefully what the best link location is.
