### PR TITLE
To-do HackMD to webpage

### DIFF
--- a/content/organization/how-to-help.md
+++ b/content/organization/how-to-help.md
@@ -7,6 +7,7 @@ We are always looking for both **people and institutions** that can promote the
 FAIRness of software management and development practice. There are many ways
 that **you can join and get involved and help the project**:
 
+## Help with the workshops
 
 ### As helper or exercise lead
 
@@ -120,6 +121,11 @@ All our material is open. It is steadily evolving and you can help us making it 
 - Also opening issues about errors or suggestions help
 - Sharing ideas/suggestions for lessons we are missing
 
+## Help the CodeRefinery project
+
+CodeRefinery is more than bi-yearly workshops. There is many ways that you can become involved and help the project to continue.
+
+We are collecting current to-do's all around the project (including the workshops) in our [collaborative document](https://hackmd.io/@coderefinery/CR_TO-DO). The best way to get started with those, is to join our [Zulip chat](https://coderefinery.zulipchat.com) and ask for more information.
 
 ### Shaping the governance structure
 


### PR DESCRIPTION
A suggestion: 

* added new headers "helping with workshops" vs "helping the project"; since most people probably know about workshops first, the to-do hackmd is pretty far down on the page. 

There is probably some nicer wording that we could come up with, as well as more points on how to help the project.

Feel free to edit, discuss etc :) 

I currently do not have the zola workflow set-up, so formatting is not checked.