### PR TITLE
Add CarpentryCon to events

### DIFF
--- a/content/workshops/other.json
+++ b/content/workshops/other.json
@@ -1,6 +1,25 @@
 {
     "events": [
         {
+            "name": "CarpentryCon 2022: Online teaching strategies from CodeRefinery",
+            "website": "https://hackmd.io/@coderefinery/carpentrycon-2022-attendee",
+            "start_date": "2022-08-03",
+            "end_date": "2022-08-03",
+            "Organizer": [
+                "Radovan Bast",
+                "Richard Darst"
+            ],
+            "instructors": [
+                "Radovan Bast",
+                "Richard Darst",
+                "Luca Ferranti",
+                "Samantha Wittke"
+            ],
+            "num_participants": {
+                "total": 15
+            }
+        },
+        {              
             "name": "Community teaching mini-workshop",
             "website": "https://hackmd.io/@coderefinery/community-teaching-2022-summer",
             "start_date": "2022-06-21",


### PR DESCRIPTION
* added Carpentry con with attendee hackMD link to "other" events
* Should HackMD stay in original shape or does it need some clean-up?
* Number of participants from a note in hackmd, is this correct?
In todo HackMD, a recording is mentioned, where is that located and should it be added here or in attendee HackMD?

I currently do not have zola workflow setup, so did not test formatting.