### PR TITLE
remove mentions of notify-me and coderefinery-announce

### DIFF
--- a/content/organization/contact.md
+++ b/content/organization/contact.md
@@ -17,18 +17,10 @@ To ask questions about workshops or services or to report issues:
 [support@coderefinery.org](mailto:support@coderefinery.org)
 
 
-### Announcements mailing list
-
-Here we will inform you about upcoming workshops, hackathons and other events.
-This is a low-traffic mailing list with 1-5 messages per month:
-<https://neic.no/mailman/listinfo/coderefinery-announce>
-
-
 ### Newsletter
 
 You can subscribe to the CodeRefinery newsletter
-[here](https://tinyletter.com/coderefinery) (we will probably later merge this
-with the announcements mailing list above in an opt-in fashion).
+[here](https://tinyletter.com/coderefinery).
 
 
 ### Twitter

--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -8,11 +8,6 @@ In short:
 - Due to the continuation of the project and to keep it possible to issue
   certificates, we will keep the workshop/hackathon/training participants'
   data from 2020 and 2021 until December 2024.
-- When we know which newsletter/notify-me platform to use in the new project
-  phase (hopefully by early next year), we will notify the current
-  newsletter/notify-me subscribers to subscribe to a new platform and
-  unsubscribe all of them from the current ones after the notification email
-  is sent.
 
 On the 1st October 2021, it was announced that CodeRefinery will receive
 partial financial support by NeIC for the next 3 years (CodeRefinery
@@ -36,7 +31,7 @@ expert helper, or exercise lead) in the currently used platform, Indico,
 managed by NeIC. The currently participating staff who is also committed to be
 a part of the CodeRefinery SP have access to the information.
 
-We continue using the newsletter and notify-me form also in the new phase but
+We continue using the newsletter in the new phase but
 we may switch to other services but in this case we would notify all
 subscribers about deletion of their contact information and invite them to
 re-register to the new services that we may migrate to.  If a user wants to
@@ -82,8 +77,6 @@ We obtain user data including person identifiable information in the following m
   - For preparation of the workshop, for example grouping of users for exercises.
   - To compare with attendance information.
   - After anonymization and summarizing, to report statistics on our website and in reports delivered to fiscal sponsors and contributing partners.
-- "notify-me" subscription form to receive notification of upcoming workshops and events.
-  - To send notification about upcoming workshops and events that the user registered as interested.
 - Email inquiry sent to support@coderefinery.org.
   - To answer the inquiry.
 - Usage report of Online video conference system showing attendance information (participant name, email address (if any), and time of entry and exit of the online event).
@@ -114,7 +107,7 @@ We obtain the following data anonymously and voluntarily from users.
 ## Who has access to the personally identifiable information?
 
 - CodeRefinery team members have access to personally identifiable information
-  provided upon workshop sign-up, "notify-me" sign-up, subscribing to our
+  provided upon workshop sign-up, subscribing to our
   newsletter, sending inquiry to support@coderefinery.org, and attendance in
   online/in-person workshops.
 

--- a/content/workshops/upcoming.md
+++ b/content/workshops/upcoming.md
@@ -20,15 +20,10 @@ is important for RSS feed. -->
 On [this page](/workshops/past/) we list all our past workshops and events.
 
 
-## Notify me
+## How to be informed about future events
 
-We don't want you to miss a workshop, whether it's an in-person
-workshop in your city or an online training event. [Sign up
-here](https://indico.neic.no/event/135/surveys/36) and tell us what
-you're interested in, and we will notify you when the registration for
-workshops and events opens. This form is also for new
-helpers and instructors, so please fill the form if you would like to
-contribute to future workshops!
+We don't want you to miss a workshop or event. The best
+way to stay informed is to join [our newsletter](https://tinyletter.com/coderefinery).
 
 You can also subscribe to our [RSS feed](/atom.xml).
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -168,15 +168,10 @@
       <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     </div>
     <div>
-      <h3>Announcements mailing list</h3>
+      <h3>Newsletter</h3>
       <p>
-        Here we will inform you about upcoming workshops, hackathons and other
-        events.  This is a low-traffic mailing list with 1-5 messages per
-        month: <a href="https://neic.no/mailman/listinfo/coderefinery-announce">https://neic.no/mailman/listinfo/coderefinery-announce</a>
-      </p>
-      <p>
-        We will probably merge the newsletter (below) into the
-        announcements mailing list in an opt-in fashion).
+        This is a low traffic newsletter about our events and updates: One email every 1 or 2 months
+        (<a href="https://tinyletter.com/coderefinery">archives</a>).
       </p>
       <form style="border:1px solid #ccc;padding:3px;text-align:center;" action="https://tinyletter.com/coderefinery" method="post" target="popupwindow" onsubmit="window.open('https://tinyletter.com/coderefinery', 'popupwindow', 'scrollbars=yes,width=600,height=600');return true"><p><label for="tlemail">Enter your email address to sign up for the CodeRefinery newsletter</label></p><p><input type="text" style="width:140px" name="email" id="tlemail" /></p><input type="hidden" value="1" name="embed"/><input type="submit" value="Subscribe" /><p><a href="https://tinyletter.com" target="_blank">powered by TinyLetter</a></p></form>
     </div>


### PR DESCRIPTION
After they are removed from the website, I will write to their subscribers and then close those services.

Note that this change also implies change in privacy policy since the notify-me form was mentioned there. I have removed its mention since we will really then also delete that form and all its data after writing to the subscribers.