### PR TITLE
config: Make description one-line to fix opengraph html properties

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,9 +3,7 @@ base_url = "https://coderefinery.org"
 
 title = "CodeRefinery"
 
-description = '''
-CodeRefinery acts as a hub for FAIR (Findable, Accessible, Interoperable, and Reusable) software practices.
-'''
+description = 'CodeRefinery acts as a hub for FAIR (Findable, Accessible, Interoperable, and Reusable) software practices.'
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true


### PR DESCRIPTION
- The line break, including the line break at the end of the string,
  appeared in the raw html
