### PR TITLE
templates/post: If page description, include it in the page itself

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -11,6 +11,11 @@
         - {{ page.extra.authors }}
       {% endif %}
     </p>
+    {% if page.description %}
+    <p class="uk-article-meta">
+      {{ page.description }}
+    </p>
+    {% endif %}
 
     <hr>
 


### PR DESCRIPTION
- Adding this as a summary might be useful, if description serves as a
  summary of the page (which it probably should)

- I have prevew-rendered it but am not sure if the styling is best -
  metadata is kind of hidden-grey.
