### PR TITLE
templates/index/twitter: Remove the Twitter embedded timeline

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -19,11 +19,13 @@
       {% set news = get_page(path="index/news.md") %}
       {{ news.content | safe }}
 
+      {% include "index/latest-blog-posts.html" %}
       {% include "index/newsletter.html" %}
     </div>
 
     <div>
-      {% include "index/latest-blog-posts.html" %}
+      {% include "index/mastodon.html" %}
+      {% include "index/twitter.html" %}
     </div>
   </div>
 
@@ -35,14 +37,4 @@
   {{ provides.content | safe }}
 
   {% include "index/cards.html" %}
-
-  <div class="uk-child-width-expand@s" uk-grid>
-    <div>
-      {% include "index/mastodon.html" %}
-    </div>
-
-    <div>
-      {% include "index/twitter.html" %}
-    </div>
-  </div>
 {% endblock content %}

--- a/templates/index/mastodon.html
+++ b/templates/index/mastodon.html
@@ -5,4 +5,4 @@
   (<a href="https://coderefinery.org/blog/2022/11/08/mastodon/">joining hints</a>).
 </p>
 
-<iframe allowfullscreen sandbox="allow-top-navigation allow-scripts" width="100%" height="400" src="https://www.mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Ffosstodon.org%2Fusers%2Fcoderefinery&theme=auto&size=80&header=true&replies=true&boosts=true"></iframe>
+<iframe allowfullscreen sandbox="allow-top-navigation allow-scripts" width="100%" height="600" src="https://www.mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Ffosstodon.org%2Fusers%2Fcoderefinery&theme=auto&size=80&header=true&replies=true&boosts=true"></iframe>

--- a/templates/index/twitter.html
+++ b/templates/index/twitter.html
@@ -1,3 +1,5 @@
 <h2>Twitter</h2>
 
-We are <a href="https://twitter.com/coderefine">CodeRefine (not -ry) on twitter</a>.
+We are <a href="https://twitter.com/coderefine">@coderefine</a>
+(without the -ry) on
+<a href="https://twitter.com/coderefine">Twitter</a>.

--- a/templates/index/twitter.html
+++ b/templates/index/twitter.html
@@ -1,7 +1,10 @@
 <h2>Twitter</h2>
 
-<a class="twitter-timeline" data-width="100%" data-height="400" href="https://twitter.com/coderefine">Tweets by coderefine</a>
+We are <a href="https://twitter.com/coderefine">CodeRefine (not -ry) on twitter</a>.
+
+<!--<a class="twitter-timeline" data-width="100%" data-height="400" href="https://twitter.com/coderefine">Tweets by coderefine</a>
 
 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+-->

--- a/templates/index/twitter.html
+++ b/templates/index/twitter.html
@@ -1,10 +1,3 @@
 <h2>Twitter</h2>
 
 We are <a href="https://twitter.com/coderefine">CodeRefine (not -ry) on twitter</a>.
-
-<!--<a class="twitter-timeline" data-width="100%" data-height="400" href="https://twitter.com/coderefine">Tweets by coderefine</a>
-
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
--->


### PR DESCRIPTION
- This adds the link and the Mastodon feed will have all the
  important announcements anyway.
- No need to give Twitter more ability to spy on all traffic from our
  site
- Review: Consider if we do, in fact, want to romeve the timeline.
