### PR TITLE
Community calls to team meetings

### DIFF
--- a/content/join/meetings.md
+++ b/content/join/meetings.md
@@ -5,35 +5,26 @@ aliases = ["/organization/meetings"]
 +++
 
 
-## Team meetings
+## Team & Community meetings
 
-Every Monday at 14 CET/CEST. Except the first Monday of the month where we have a
-call with more community focus (see below).
+Every Monday at 14 CET/CEST.
 
-Scope: Making sure everything fits together; improving the processes, website
-and documentation; information exchange; bouncing ideas off others. This is
-the place where day-to-day decisions are made, but any major decisions will
-also be discussed in chat, over several weeks, or in other meetings
-such as the community call or with the steering group. Despite the
-name, everyone is welcome to this event too.
+We welcome anyone interested in CodeRefinery to join our weekly team meetings.  
+This is the place to drop by if you would like to get involved but don't know where to start.
 
 - [Next meeting agenda and connection details](https://hackmd.io/@coderefinery/team-meeting)
-- Calendar invites: [Subscribe to "team events" calendar here](https://coderefinery.github.io/calendar/), which includes community calls below.
+- Calendar invites: [Subscribe to "team events" calendar here](https://coderefinery.github.io/calendar/), which includes these meetings.
+
+#### Scope: 
+- Making sure everything fits together
+- Workshop scheduling, governance, and roadmap
+- Improving the processes, website and documentation
+- Information exchange
+- Bouncing ideas off others
+- Making day-to-day decisions
+  - Any major decisions are also discussed in [Zulipchat](https://coderefinery.zulipchat.com) or with the the steering group. 
 
 
-## Community calls
-
-Held on a monthly interval on Mondays at 14 CET/CEST,
-the **first Monday of a month**.
-
-Scope: All topics involving community onboarding, "what can I do?",
-workshop scheduling, governance, and roadmap.  This is the place to
-drop by if you would like to get involved but don't know where to start.
-
-- [Next meeting agenda and connection details](https://hackmd.io/@coderefinery/community-call)
-- Calendar invites: [Subscribe to "CodeRefinery community calls"
-  calendar here](https://coderefinery.github.io/calendar/), or the
-  "team events" as in the link above.
 
 
 ### Archive of past community calls

--- a/content/join/meetings.md
+++ b/content/join/meetings.md
@@ -9,22 +9,23 @@ aliases = ["/organization/meetings"]
 
 Every Monday at 14 CET/CEST.
 
-We welcome anyone interested in CodeRefinery to join our weekly team meetings.  
-This is the place to drop by if you would like to get involved but don't know where to start.
+We welcome everyone interested in CodeRefinery to join our weekly meetings.
+This is the place to drop by if you have questions or would like to get
+involved but don't know where to start.
 
 - [Next meeting agenda and connection details](https://hackmd.io/@coderefinery/team-meeting)
-- Calendar invites: [Subscribe to "team events" calendar here](https://coderefinery.github.io/calendar/), which includes these meetings.
+- Calendar invites: [Subscribe to "team events" calendar here](/calendars/), which includes these meetings.
 
-#### Scope: 
+
+### Scope
+
+- Information exchange
 - Making sure everything fits together
 - Workshop scheduling, governance, and roadmap
-- Improving the processes, website and documentation
-- Information exchange
+- Improving the processes, website, and documentation
 - Bouncing ideas off others
 - Making day-to-day decisions
-  - Any major decisions are also discussed in [Zulipchat](https://coderefinery.zulipchat.com) or with the the steering group. 
-
-
+- Major decisions are also discussed in the [Zulipchat](https://coderefinery.zulipchat.com) or with the steering group
 
 
 ### Archive of past community calls


### PR DESCRIPTION
Not the meetings page looks nice but I think still https://coderefinery.github.io/calendar/ needs to be edited for the community call calendar