### PR TITLE
Added lessons learned for March 2023 workshop

### DIFF
--- a/content/blog/2023-04-12-lessons-learned-mar-2023.md
+++ b/content/blog/2023-04-12-lessons-learned-mar-2023.md
@@ -1,0 +1,128 @@
++++
+title = "Lessons learned from the March 2023 online workshop"
+slug = "2023/03/21/lessons-learned-Mar-2023"
+
+[extra]
+authors = "Stephan Smuts"
++++
+
+March 21-23 and 28-30, 2023, we held again our [CodeRefinery online
+workshop](https://coderefinery.github.io/2023-03-21-workshop/) (6 x 3.5 hours)
+with ... individual registrants plus ... teams with a total of ... participants.
+Here we wish to share with the community and our future selves our lessons
+learned: What worked well and what we need and plan to improve. We use bullet
+point format for brevity. If you think you might have solutions for us or want
+to discuss about the topic, please [reach out to
+us(https://coderefinery.org/organization/contact/). This complements our
+lessons learned from [our first online workshop
+2020](https://coderefinery.org/blog/2020/04/14/first-online-workshop/), the
+[May 2021
+workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/) and the [Sep 2022 workshop](https://coderefinery.org/blog/2022/11/08/lessons-learned-Sep-2022/)
+
+**We have identified the following main issues that we want to address for future events**:
+
+- Some participants suggested speaking more clearly, improving mic quality, and recommending participants to get familiar with Vim, Nano, etc. before the workshop starts
+- Some attendees expressed confusion with some exercises and recommended more repetition of basic commands and more concrete examples of solutions in exercises
+- Some attendees suggested improving the teaching style by doing exercises while explaining each step, while others preferred doing the exercises themselves for better learning
+- Suggestions for improvements, such as providing more support for online participants and having more, smaller repositories for exercises
+- Some participants found certain aspects of the training confusing, such as the merging process
+- Suggestion for instructors to provide clearer instructions
+- Some participants wanted more hands-on exercises and more information on specific topics like environments, MATLAB, and good documentation and attribution practices.
+- The participants suggested expanding the course duration or offering a series of mini workshops.
+- They also suggested covering ethics and copyright law and providing solutions to exercises directly under each question.
+- There are suggestions for improvement, including making the content more linear, explaining concepts in more detail, and providing more examples.
+- The use of Sphinx, a documentation tool, was discussed, and some participants were unsure of its value.
+- Suggestions for improvements included providing more information on common practices and beginner's mistakes, as well as offering more focused mentorship and help sessions after the course.
+- Some participants felt that the daily schedule could be shorter or more compact.
+- Cheat sheets or code checkpoints could be provided to help with finding information quickly.
+
+# Summaries
+
+## Day 1
+
+- The workshop was just right in terms of pace and highly recommendable to others
+- Participants appreciated the hands-on experience, type-along exercises, availability of workshop material, and the responsiveness of the collaborative document
+- Some participants suggested speaking more clearly, improving mic quality, and recommending participants to get familiar with Vim, Nano, etc. before the workshop starts
+- Overall, participants enjoyed the workshop and would like to join more like this
+
+## Day 2
+
+- The speed and level of the workshop were appropriate and engaging
+- Several positive comments on the commands and examples covered, the breaks provided, and the helpfulness of the instructors
+- Some attendees expressed confusion with some exercises and recommended more repetition of basic commands and more concrete examples of solutions in exercises
+- Some attendees suggested improving the teaching style by doing exercises while explaining each step, while others preferred doing the exercises themselves for better learning
+- Technical questions were asked about the official Git documentation, the use of Overleaf, and the concept of stash, which were addressed by the instructors
+- Some attendees provided personal comments and suggestions for future workshops, including the possibility of working on a test project together and adding prompts to show the branch in Git repositories.
+
+## Day 3
+
+- General consensus that the pace of the training was appropriate
+- Many participants found the hands-on work helpful
+- Some participants encountered technical difficulties
+- Suggestions for improvements, such as providing more support for online participants and having more, smaller repositories for exercises
+- Some participants found certain aspects of the training confusing, such as the merging process
+- Suggestion for instructors to provide clearer instructions
+- Overall, a positive response to the training
+- Many participants indicated that they learned useful skills that they can apply in their work.
+
+## Day 4
+
+- The participants found the speed of the course to be appropriate.
+- They appreciated learning about containers and dockers, as well as Snakemake, licensing, and R examples.
+- Some participants wanted more hands-on exercises and more information on specific topics like environments, MATLAB, and good documentation and attribution practices.
+- The participants suggested expanding the course duration or offering a series of mini workshops.
+- They also suggested covering ethics and copyright law and providing solutions to exercises directly under each question.
+- Overall, the participants enjoyed the course and found it to be informative and useful.
+
+## Day 5
+
+- Participants have varying opinions on the pace, level, and usefulness of the workshop.
+- Some participants found the tools introduced to be too advanced, while others found them to be a good challenge.
+- There are suggestions for improvement, including making the content more linear, explaining concepts in more detail, and providing more examples.
+- The use of Sphinx, a documentation tool, was discussed, and some participants were unsure of its value.
+- Overall, participants found the workshop to be informative and inspiring, with some planning to spend additional time reviewing the content.
+
+## Day 6
+
+- The course was generally well-received and appreciated.
+- Many participants felt that they learned useful skills and would recommend the course to others.
+- Suggestions for improvements included providing more information on common practices and beginner's mistakes, as well as offering more focused mentorship and help sessions after the course.
+- Some participants felt that the daily schedule could be shorter or more compact.
+- Cheat sheets or code checkpoints could be provided to help with finding information quickly.
+- Technical concerns included difficulty with using the automatic debugging tool in GitHub.
+- There were also some questions about how to receive course credits or certificates.
+
+### Registration
+
+- The registration process has definitely been improved, but we have identified that it could be further streamlined.
+
+### Workshop format
+
+- We changed the format slightly this time around in that we removed the group Zoom rooms.
+
+### Coordination
+
+-
+
+### Zoom and Twitch
+
+- Before this workshop we had decided to do away with the group Zoom rooms because it proved to be a lot of work for inconsistent results.
+  - In previous workshops we found that the problems start to mount when members don't show up for the group they signed up for. As the workshop progresses, there is a drop in attendance and this affects the Zoom breakout rooms. This in and of itself is not a big problem, but we found that we get some rooms that are completely empty; some rooms are at full capacity; and some rooms have 1 or 2 people. We then have to asses each day and rearrange people together with expert helpers. This proved to be more work for little improvement in the quality of the workshop. So, we decided to do away with the group rooms for this workshop and focus only on the collaborative document.
+
+### Collaborative notes
+
+- As was mentioned above, we had more hands on the collaborative document since we did away with the Zoom rooms. This proved to work well because we had a lot more people answering questions, so the document was kept updated and archived for maximum performance and accuracy.
+
+### Installation and tools
+
+-
+
+### Lesson content
+
+- We are constantly looking at improving the quality of the lessons we provide, so this is an ongoing process.
+  - We take into consideration all the feedback that is given through the collaborative document to inform our decisions on where we should focus for lesson improvement.
+
+### Communication with participants
+
+- Add all sessions to the [CodeRefinery calendar](https://coderefinery.org/calendars/).
+- Link all relevant repositories in one place (i.e. this calendar and anything that needs attention near a workshop). Make sure those repositories have good instructions in READMEs.

--- a/content/blog/2023-04-12-lessons-learned-mar-2023.md
+++ b/content/blog/2023-04-12-lessons-learned-mar-2023.md
@@ -122,6 +122,8 @@ workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/) an
 
 ### Lesson content
 
+We could shorten the lecture-part by moving exercises to the end. 
+Longer exercises would benefit in onsite rooms.
 - We are constantly looking at improving the quality of the lessons we provide, so this is an ongoing process.
   - We take into consideration all the feedback that is given through the collaborative document to inform our decisions on where we should focus for lesson improvement.
 

--- a/content/blog/2023-04-12-lessons-learned-mar-2023.md
+++ b/content/blog/2023-04-12-lessons-learned-mar-2023.md
@@ -99,6 +99,7 @@ workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/) an
 ### Workshop format
 
 - We changed the format slightly this time around in that we removed the group Zoom rooms.
+  - It was easier to organise.
 
 ### Coordination
 

--- a/content/blog/2023-04-12-lessons-learned-mar-2023.md
+++ b/content/blog/2023-04-12-lessons-learned-mar-2023.md
@@ -8,7 +8,7 @@ authors = "Stephan Smuts"
 
 March 21-23 and 28-30, 2023, we held again our [CodeRefinery online
 workshop](https://coderefinery.github.io/2023-03-21-workshop/) (6 x 3.5 hours)
-with ... individual registrants plus ... teams with a total of ... participants.
+with 493 individual registrants and 100-200 views on average in Twitch.
 Here we wish to share with the community and our future selves our lessons
 learned: What worked well and what we need and plan to improve. We use bullet
 point format for brevity. If you think you might have solutions for us or want

--- a/content/blog/2023-04-12-lessons-learned-mar-2023.md
+++ b/content/blog/2023-04-12-lessons-learned-mar-2023.md
@@ -1,6 +1,6 @@
 +++
 title = "Lessons learned from the March 2023 online workshop"
-slug = "2023/03/21/lessons-learned-Mar-2023"
+slug = "2023/04/12/lessons-learned-mar-2023"
 
 [extra]
 authors = "Stephan Smuts"
@@ -10,23 +10,29 @@ March 21-23 and 28-30, 2023, we held again our [CodeRefinery online
 workshop](https://coderefinery.github.io/2023-03-21-workshop/) (6 x 3.5 hours)
 with 493 individual registrants and 100-200 views on average in Twitch.
 Here we wish to share with the community and our future selves our lessons
-learned: What worked well and what we need and plan to improve. We use bullet
-point format for brevity. If you think you might have solutions for us or want
+learned: What worked well and what we need and plan to improve.
+
+If you think you might have solutions for us or want
 to discuss about the topic, please [reach out to
-us(https://coderefinery.org/organization/contact/). This complements our
+us](https://coderefinery.org/organization/contact/). This complements our
 lessons learned from [our first online workshop
 2020](https://coderefinery.org/blog/2020/04/14/first-online-workshop/), the
 [May 2021
-workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/) and the [Sep 2022 workshop](https://coderefinery.org/blog/2022/11/08/lessons-learned-Sep-2022/)
+workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/),
+and the [Sep 2022 workshop](https://coderefinery.org/blog/2022/11/08/lessons-learned-Sep-2022/).
 
 **We have identified the following main issues that we want to address for future events**:
 
-- Some participants suggested speaking more clearly, improving mic quality, and recommending participants to get familiar with Vim, Nano, etc. before the workshop starts
-- Some attendees expressed confusion with some exercises and recommended more repetition of basic commands and more concrete examples of solutions in exercises
-- Some attendees suggested improving the teaching style by doing exercises while explaining each step, while others preferred doing the exercises themselves for better learning
-- Suggestions for improvements, such as providing more support for online participants and having more, smaller repositories for exercises
-- Some participants found certain aspects of the training confusing, such as the merging process
-- Suggestion for instructors to provide clearer instructions
+- Speaking more clearly, improving mic quality, and recommending participants to get familiar with Vim, Nano, etc. before the workshop starts.
+- Some attendees expressed confusion with some exercises and recommended more
+  repetition of basic commands and more concrete examples of solutions in
+  exercises.
+- Some attendees suggested improving the teaching style by doing exercises
+  while explaining each step, while others preferred doing the exercises
+  themselves for better learning.
+- Provide more support for online participants and having more, smaller repositories for exercises.
+- Some participants found certain aspects of the training confusing, such as the merging process.
+- Provide clearer instructions.
 - Some participants wanted more hands-on exercises and more information on specific topics like environments, MATLAB, and good documentation and attribution practices.
 - The participants suggested expanding the course duration or offering a series of mini workshops.
 - They also suggested covering ethics and copyright law and providing solutions to exercises directly under each question.
@@ -36,45 +42,64 @@ workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/) an
 - Some participants felt that the daily schedule could be shorter or more compact.
 - Cheat sheets or code checkpoints could be provided to help with finding information quickly.
 
-# Summaries
 
-## Day 1
+## Daily summaries
 
-- The workshop was just right in terms of pace and highly recommendable to others
-- Participants appreciated the hands-on experience, type-along exercises, availability of workshop material, and the responsiveness of the collaborative document
-- Some participants suggested speaking more clearly, improving mic quality, and recommending participants to get familiar with Vim, Nano, etc. before the workshop starts
-- Overall, participants enjoyed the workshop and would like to join more like this
+### Day 1
 
-## Day 2
+- The workshop was just right in terms of pace and highly recommendable to others.
+- Participants appreciated the hands-on experience, type-along exercises,
+  availability of workshop material, and the responsiveness of the
+  collaborative document.
+- Some participants suggested speaking more clearly, improving mic quality, and
+  recommending participants to get familiar with Vim, Nano, etc. before the
+  workshop starts.
+- Overall, participants enjoyed the workshop and would like to join more like this.
 
-- The speed and level of the workshop were appropriate and engaging
-- Several positive comments on the commands and examples covered, the breaks provided, and the helpfulness of the instructors
-- Some attendees expressed confusion with some exercises and recommended more repetition of basic commands and more concrete examples of solutions in exercises
-- Some attendees suggested improving the teaching style by doing exercises while explaining each step, while others preferred doing the exercises themselves for better learning
-- Technical questions were asked about the official Git documentation, the use of Overleaf, and the concept of stash, which were addressed by the instructors
-- Some attendees provided personal comments and suggestions for future workshops, including the possibility of working on a test project together and adding prompts to show the branch in Git repositories.
 
-## Day 3
+### Day 2
 
-- General consensus that the pace of the training was appropriate
-- Many participants found the hands-on work helpful
-- Some participants encountered technical difficulties
-- Suggestions for improvements, such as providing more support for online participants and having more, smaller repositories for exercises
-- Some participants found certain aspects of the training confusing, such as the merging process
-- Suggestion for instructors to provide clearer instructions
-- Overall, a positive response to the training
+- The speed and level of the workshop were appropriate and engaging.
+- Several positive comments on the commands and examples covered, the breaks provided, and the helpfulness of the instructors.
+- Some attendees expressed confusion with some exercises and recommended more
+  repetition of basic commands and more concrete examples of solutions in
+  exercises.
+- Some attendees suggested improving the teaching style by doing exercises
+  while explaining each step, while others preferred doing the exercises
+  themselves for better learning.
+- Technical questions were asked about the official Git documentation, the use
+  of Overleaf, and the concept of stash, which were addressed by the
+  instructors.
+- Some attendees provided personal comments and suggestions for future
+  workshops, including the possibility of working on a test project together
+  and adding prompts to show the branch in Git repositories.
+
+
+### Day 3
+
+- General consensus that the pace of the training was appropriate.
+- Many participants found the hands-on work helpful.
+- Some participants encountered technical difficulties.
+- Suggestions for improvements, such as providing more support for online participants and having more, smaller repositories for exercises.
+- Some participants found certain aspects of the training confusing, such as the merging process.
+- Suggestion for instructors to provide clearer instructions.
+- Overall, a positive response to the training.
 - Many participants indicated that they learned useful skills that they can apply in their work.
 
-## Day 4
+
+### Day 4
 
 - The participants found the speed of the course to be appropriate.
-- They appreciated learning about containers and dockers, as well as Snakemake, licensing, and R examples.
-- Some participants wanted more hands-on exercises and more information on specific topics like environments, MATLAB, and good documentation and attribution practices.
+- They appreciated learning about containers, as well as Snakemake, licensing, and R examples.
+- Some participants wanted more hands-on exercises and more information on
+  specific topics like environments, MATLAB, and good documentation and
+  attribution practices.
 - The participants suggested expanding the course duration or offering a series of mini workshops.
 - They also suggested covering ethics and copyright law and providing solutions to exercises directly under each question.
 - Overall, the participants enjoyed the course and found it to be informative and useful.
 
-## Day 5
+
+### Day 5
 
 - Participants have varying opinions on the pace, level, and usefulness of the workshop.
 - Some participants found the tools introduced to be too advanced, while others found them to be a good challenge.
@@ -82,7 +107,8 @@ workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/) an
 - The use of Sphinx, a documentation tool, was discussed, and some participants were unsure of its value.
 - Overall, participants found the workshop to be informative and inspiring, with some planning to spend additional time reviewing the content.
 
-## Day 6
+
+### Day 6
 
 - The course was generally well-received and appreciated.
 - Many participants felt that they learned useful skills and would recommend the course to others.
@@ -92,42 +118,59 @@ workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/) an
 - Technical concerns included difficulty with using the automatic debugging tool in GitHub.
 - There were also some questions about how to receive course credits or certificates.
 
-### Registration
+
+## Registration
 
 - The registration process has definitely been improved, but we have identified that it could be further streamlined.
+- Our initial ambition was to register participants in two steps: in the first step to make sure they get all following
+  information, and in the second step signing up more concretely to a specific format. But during the registration we
+  decided to not ask all registrants to update their registrations. For future we wish to make this one-step.
 
-### Workshop format
 
-- We changed the format slightly this time around in that we removed the group Zoom rooms.
-  - It was easier to organise.
+## Zoom and Twitch
 
-### Coordination
+- Before this workshop we had decided to do away with the group Zoom rooms
+  because it proved to be a lot of work for inconsistent results.
+  In previous workshops we found that the problems start to mount when
+  members don't show up for the group they signed up for. As the workshop
+  progresses, there is a drop in attendance and this affects the Zoom
+  breakout rooms. This in and of itself is not a big problem, but we found
+  that we get some rooms that are completely empty; some rooms are at full
+  capacity; and some rooms have 1 or 2 people. We then have to asses each day
+  and rearrange people together with expert helpers. This proved to be more
+  work for little improvement in the quality of the workshop. So, we decided
+  to do away with the group rooms for this workshop and focus only on the
+  collaborative document.
 
--
 
-### Zoom and Twitch
+## Collaborative notes
 
-- Before this workshop we had decided to do away with the group Zoom rooms because it proved to be a lot of work for inconsistent results.
-  - In previous workshops we found that the problems start to mount when members don't show up for the group they signed up for. As the workshop progresses, there is a drop in attendance and this affects the Zoom breakout rooms. This in and of itself is not a big problem, but we found that we get some rooms that are completely empty; some rooms are at full capacity; and some rooms have 1 or 2 people. We then have to asses each day and rearrange people together with expert helpers. This proved to be more work for little improvement in the quality of the workshop. So, we decided to do away with the group rooms for this workshop and focus only on the collaborative document.
+- As was mentioned above, we had more hands on the collaborative document since
+  we did away with the Zoom rooms. This proved to work well because we had a
+  lot more people answering questions, so the document was kept updated and
+  archived for maximum performance and accuracy.
 
-### Collaborative notes
 
-- As was mentioned above, we had more hands on the collaborative document since we did away with the Zoom rooms. This proved to work well because we had a lot more people answering questions, so the document was kept updated and archived for maximum performance and accuracy.
+## Installation and tools
 
-### Installation and tools
+- We could have a demo exercise (or some) that people can test before the
+  workshop: "If you feel comfortable with this you’re gonna be fine during the
+  workshop".
 
-- We could have a demo exercise (or some) that people can test before the workshop
-  - “If you feel comfortable with this you’re gonna be fine during the workshop”
--
 
-### Lesson content
+## Lesson content
 
-We could shorten the lecture-part by moving exercises to the end. 
-Longer exercises would benefit in onsite rooms.
-- We are constantly looking at improving the quality of the lessons we provide, so this is an ongoing process.
-  - We take into consideration all the feedback that is given through the collaborative document to inform our decisions on where we should focus for lesson improvement.
+- We could shorten the lecture-part by moving exercises to the end. 
+- Longer exercises would benefit in on-site rooms.
+- We are constantly looking at improving the quality of the lessons we provide,
+  so this is an ongoing process. We take into consideration all the feedback
+  that is given through the collaborative document to inform our decisions on
+  where we should focus for lesson improvement.
 
-### Communication with participants
+
+## Communication with participants
 
 - Add all sessions to the [CodeRefinery calendar](https://coderefinery.org/calendars/).
-- Link all relevant repositories in one place (i.e. this calendar and anything that needs attention near a workshop). Make sure those repositories have good instructions in READMEs.
+- Link all relevant repositories in one place (i.e. this calendar and anything
+  that needs attention near a workshop). Make sure those repositories have good
+  instructions in READMEs.

--- a/content/blog/2023-04-12-lessons-learned-mar-2023.md
+++ b/content/blog/2023-04-12-lessons-learned-mar-2023.md
@@ -114,6 +114,7 @@ workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/) an
 - As was mentioned above, we had more hands on the collaborative document since we did away with the Zoom rooms. This proved to work well because we had a lot more people answering questions, so the document was kept updated and archived for maximum performance and accuracy.
 
 ### Installation and tools
+
 - We could have a demo exercise (or some) that people can test before the workshop
   - “If you feel comfortable with this you’re gonna be fine during the workshop”
 -

--- a/content/blog/2023-04-12-lessons-learned-mar-2023.md
+++ b/content/blog/2023-04-12-lessons-learned-mar-2023.md
@@ -114,7 +114,8 @@ workshop](https://coderefinery.org/blog/2021/11/25/lessons-learned-may-2021/) an
 - As was mentioned above, we had more hands on the collaborative document since we did away with the Zoom rooms. This proved to work well because we had a lot more people answering questions, so the document was kept updated and archived for maximum performance and accuracy.
 
 ### Installation and tools
-
+- We could have a demo exercise (or some) that people can test before the workshop
+  - “If you feel comfortable with this you’re gonna be fine during the workshop”
 -
 
 ### Lesson content


### PR DESCRIPTION
I have added a blogpost for the March 2023 workshop with some initial thoughts. I've used the structure of the previous blog post. The main points are under the first heading "We have identified the following main issues that we want to address for future events" under which I have added summaries for each day where those who want to contribute can get a quick overview. I will remove those summaries before publishing to the website because they are for reference now while I get input from CR members. 
@MatiasJJ Could you add some stats as we spoke about during the team meeting?