### PR TITLE
content/index/news: Relink past workshop, dates for future.

### DIFF
--- a/content/index/news.md
+++ b/content/index/news.md
@@ -4,3 +4,10 @@
 ## News
 
 - Our September workshop just finished. We will soon share our lessons learned and the plan forward.
+- We are thinking 12-14 and 19-21 March, 2024, for our next workshop.
+  But the format may be changed and dates adjusted to fit the new
+  format.
+- Our last workshop was [Tue-Thu, September 19-21 and 26-28 (6
+  half-days,
+  online)](https://coderefinery.github.io/2023-09-19-workshop/) - you
+  can continue to browsed and self-studied.


### PR DESCRIPTION
- Re-link the past workshop under news.  Seeing the past is probably
  useful for visitors who want to see what it is we do (and easier to
  find it in news than clicking to past workshops).  It helps in our
  advertisements.
- Add next workshop proposed dates, but clearly say it's not fixed.
- Review: automerge 3d
