### PR TITLE
Add train the trainer, update kickstart to "past"

### DIFF
--- a/content/index/news.md
+++ b/content/index/news.md
@@ -4,9 +4,8 @@
 ## News
 
 - **CodeRefinery train the trainer workshop** on four Tuesdays between
-  August 13 and September 3, 9-12 CEST. Preliminary registration is open:
-  https://indico.neic.no/e/CR-ttt24 ; event page will be available soon.
-  To be informed, sign up for our [newsletter](/about/newsletter/).  
+  August 13 and September 3, 9-12 CEST.
+  [Registration and more information](https://coderefinery.github.io/train-the-trainer/)  
 - **Our next standard CodeRefinery workshop is September 10-12 & 17-19,
   2024.** There is no website yet but it will be similar to the [March
   workshop](https://coderefinery.github.io/2024-03-12-workshop/).  To

--- a/content/index/news.md
+++ b/content/index/news.md
@@ -3,6 +3,10 @@
 
 ## News
 
+- **CodeRefinery train the trainer workshop** on four Tuesdays between
+  August 13 and September 3, 9-12 CEST. Preliminary registration is open:
+  https://indico.neic.no/e/CR-ttt24 ; event page will be available soon.
+  To be informed, sign up for our [newsletter](/about/newsletter/).  
 - **Our next standard CodeRefinery workshop is September 10-12 & 17-19,
   2024.** There is no website yet but it will be similar to the [March
   workshop](https://coderefinery.github.io/2024-03-12-workshop/).  To
@@ -10,11 +14,11 @@
   [newsletter](/about/newsletter/).
 - [Aalto University Scientific Computing/HPC
   Kickstart](https://scicomp.aalto.fi/training/scip/kickstart-2024/)
-  (4-6 June 2024) is livestreamed in the CodeRefinery style and open to
-  all.
+  (happened 4-6 June 2024) was livestreamed in the CodeRefinery style and open to
+  all. Materials and recordings available.
 - [Tuesday Tools & Techniques for High Performance Computing,
   April-May
   2024](https://scicomp.aalto.fi/training/scip/ttt4hpc-2024/), has just
   ended - material and videos are available.
 - Long-term outlook: [Python for Scientific Computing](https://aaltoscicomp.github.io/python-for-scicomp/) likely in
-  October or November.  The following standard tools workshop in spring 2025.
+  November.  The following standard tools workshop in spring 2025.


### PR DESCRIPTION
Preliminary registration for train the trainer added to main page. Will update once the course landing page is ready. 