### PR TITLE
add link to workshop webpage

### DIFF
--- a/content/index/news.md
+++ b/content/index/news.md
@@ -7,10 +7,7 @@
   August 13 and September 3, 9-12 CEST.
   [Registration and more information](https://coderefinery.github.io/train-the-trainer/)  
 - **Our next standard CodeRefinery workshop is September 10-12 & 17-19,
-  2024.** There is no website yet but it will be similar to the [March
-  workshop](https://coderefinery.github.io/2024-03-12-workshop/).  To
-  be informed, sign up for our
-  [newsletter](/about/newsletter/).
+  2024.** More information and registration on the [workshop website](https://coderefinery.github.io/2024-09-10-workshop/)
 - [Aalto University Scientific Computing/HPC
   Kickstart](https://scicomp.aalto.fi/training/scip/kickstart-2024/)
   (happened 4-6 June 2024) was livestreamed in the CodeRefinery style and open to

--- a/content/workshops/upcoming.md
+++ b/content/workshops/upcoming.md
@@ -15,6 +15,11 @@ way to stay informed is to join [our newsletter](@/about/newsletter.md)
 You can also subscribe to our [RSS feed](/atom.xml).
 
 - [Tue-Thu, August 27-29 (3 full days, Gothenburg)](https://coderefinery.github.io/2024-08-27-gothenburg/)
+- [Tue-Thu, September 10-12 and 17-19 (6 half-days, online)](https://coderefinery.github.io/2024-09-10-workshop/)
+
+## CodeRefinery train the trainer workshop
+
+- [Every Tuesday between August 13 and September 3 (4 half days, online)](https://coderefinery.github.io/train-the-trainer/)
 
 ## Upcoming workshops from partner organizations
 


### PR DESCRIPTION
Noticed that it still said that there is no workshop webpage...

But just in case there is a reason for it not being public, leaving it up to @eglerean and @dianaiusan  to merge.