### PR TITLE
Fix many broken links; closes #928

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,6 +31,11 @@ skip_prefixes = [
     "https://cicero.xyz",
     "https://sandbox.zenodo.org",
 ]
+# do not check blog posts for broken external links
+ignored_files = [
+    "*/content/blog/*",
+    "*/content/open-house/*",
+]
 
 [extra]
 # Put all your custom variables here

--- a/content/about/code-of-conduct.md
+++ b/content/about/code-of-conduct.md
@@ -11,7 +11,7 @@ contributing. All participants in our events and communications are expected to
 show respect and courtesy to others. 
 
 We follow [the Code of Conduct by the
-Carpentries](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
+Carpentries](https://docs.carpentries.org/policies/coc/)
 as primary principles.  Here is a summary of CodeRefinery's Code of Conduct
 adapted from the Carpentries Code of Conduct:
 

--- a/content/about/partners.md
+++ b/content/about/partners.md
@@ -212,9 +212,8 @@ organizations](@/join/organizations.md) on how your organization can join.
 <img src="/about/funding/asc.png" alt="logo: Aalto Scientific Computing" width="100px">
 
 ASC has been involved in CodeRefinery since 2017.
-- Web: [scicomp.aalto.fi](https://scicomp.aalto.fi/)
-- Learner support:
-  [scicomp.aalto.fi/help/](https://scicomp.aalto.f/help/)
+- Web: <https://scicomp.aalto.fi>
+- Learner support: <https://scicomp.aalto.fi/help/>
 - Contact: Richard Darst via [CodeRefinery
   chat](https://coderefinery.github.io/manuals/chat/).
 - Provides local registration and breakout rooms for most core

--- a/content/about/presentations.md
+++ b/content/about/presentations.md
@@ -35,7 +35,7 @@ and find the source in `markdown` and LibreOffice Impress `odp` format in our
   Reproducibility through Research
   Code](https://rsse.africa/events-rsse-africa/2024-11-14/), Nov 14, 2024
   ([blog post](https://rsse.africa/post/2024/12/open-science-episode2/)).
-- CarpentryConnect in Heidelberg, Germany in November 2024: [Poster](https://github.com/coderefinery/posters/blob/main/2024_CarpentryCon.pdf)
+- CarpentryConnect in Heidelberg, Germany in November 2024: [Poster](https://github.com/coderefinery/posters/blob/main/2024_CarpentryCon/2024_CarpentryCon.pdf)
   and [lightning talk](https://github.com/coderefinery/presentations/blob/main/2024-CarpentryCon.pdf) on ["Teaching 'good enough' research software engineering skills"](https://doi.org/10.5281/zenodo.14739411) (Samantha Wittke)
 - ["The CodeRefinery project for training in research software engineering"](https://cicero.xyz/v3/remark/0.14.0/github.com/coderefinery/presentations/main/2024-hpc-train-ecosystem-europe.md/)
   at [The HPC Training Ecosystem in Europe (Online)](https://enccs.se/news/2024/10/the-hpc-training-ecosystem-in-europe/),
@@ -77,7 +77,7 @@ and find the source in `markdown` and LibreOffice Impress `odp` format in our
 ## 2022
 
 - ["About the CodeRefinery project"](https://doi.org/10.5446/60140) at the
-  [EuSSI training bazaar](https://eussi.org/bazaar/) - Nov 21, 2022 (Matias Jääskeläinen)
+  EuSSI training bazaar, Nov 21, 2022 (Matias Jääskeläinen)
 - "CodeRefinery - a hub for FAIR Software practices" at
   [DeiC conference 2022](https://www.deic.dk/en/conference/2022/program-day-1) (Radovan Bast)
 

--- a/content/about/reports/_index.md
+++ b/content/about/reports/_index.md
@@ -6,7 +6,7 @@ description = "Collection of news articles, blog posts, and reports about CodeRe
 ## Articles and blog posts about CodeRefinery
 
 - [CodeRefinery
-  Continues](https://www.kth.se/polopoly_fs/1.1214879.1671148072!/Newsletter2022-2-final_lres_spreads.pdf),
+  Continues](https://www.pdc.kth.se/about/publications/pdc-newsletter-2022-no-2/coderefinery-continues-1.1208794)
   article in PDC 2022.2 newsletter (KTH, Sweden)
 - [Training that connects people (2022 NeIC news article)](https://neic.no/news/2022/09/15/sixth-success-story/)
 - [CodeRefinery workshop: Nettkurs for utviklere av forskningsprogramvare](https://www.usit.uio.no/om/organisasjon/itf/ds/task/task-bloggen/coderefinery-workshop.html)
@@ -21,7 +21,7 @@ description = "Collection of news articles, blog posts, and reports about CodeRe
   (Aalto University news)
 - *A FAIRer future*, [Nature Physics 15, 728–730 (2019)](https://doi.org/10.1038/s41567-019-0624-3)
 - *Bättre datahantering gör forskning mer reproducerbar*, [article in the Curie newsletter](https://www.tidningencurie.se/nyheter/2019/04/23/battre-datahantering-gor-forskning-mer-reproducerbar/) from the Swedish Research Council
-- *CodeRefinery 2.0*, [PDC December 2018 newsletter](https://www.pdc.kth.se/publications/pdc-newsletter-articles/2018-no-2/coderefinery-2-0-1.864580) and [Titan.uio.no blog post](https://titan.uio.no/node/3162)
+- *CodeRefinery 2.0*, [PDC December 2018 newsletter](https://www.kth.se/polopoly_fs/1.865417.1600689934!/Newsletter2018-2-final-lres.pdf) and [Titan.uio.no blog post](https://www.titan.uio.no/blogg/forskerbloggen/2018/coderefinery-20.html)
 - *Teaching researchers to write better code*, [https://www.inthefieldstories.net/teaching-researchers-to-write-better-code/](https://www.inthefieldstories.net/teaching-researchers-to-write-better-code/)
 - *Better software leads to better science*, [NeIC news article](https://neic.no/news/2017/03/15/better-software-leads-to-better-science/)
 - *First Year of CodeRefinery*, PDC December 2017 newsletter

--- a/content/lessons/other.md
+++ b/content/lessons/other.md
@@ -88,7 +88,7 @@ a community you can join and give contributions to:
 - [rOpenSci: Transforming science through open data](http://ropensci.org)
 - [NumFOCUS](http://www.numfocus.org)
 - [Oxford Research Software Engineering group](https://train.oxrse.uk/)
-- [NASA TOPS Open Science 101](https://openscience101.org/)
+- [NASA TOPS Open Science 101](https://science.nasa.gov/open-science/os101/)
 - [Netherlands eScience Center](https://www.esciencecenter.nl)
 - [The Turing Way](https://the-turing-way.netlify.app/)
 - [The Programming Historian](https://programminghistorian.org/en/lessons/)


### PR DESCRIPTION
This was detected using `zola check`.

In config.toml we now ignore `*/content/blog/*` and `*/content/open-house/*` when running `zola check` since I found it excessive to go through old blog posts and fixing links there.