### PR TITLE
Add link to workshop page

### DIFF
--- a/content/index/news.md
+++ b/content/index/news.md
@@ -3,7 +3,7 @@
 
 ## Upcoming workshops and other news
 
-- CodeRefinery tools workshop (online) - September 9-11 2025 + 6 following Wednesdays (new format - registration opening soon!)
+- [CodeRefinery tools workshop (online)](https://coderefinery.github.io/2025-09-09-workshop/) - September 9-11 2025 + 6 following Wednesdays (new format - registration opening soon!)
 - We have a short [slideset about CodeRefinery](@/about/presentations.md) which you can reuse in own presentations.
 - Recently we recorded a [Shell crash course](https://youtu.be/xbTTDLA3txI)
   which can be used as preparation for those who wish to follow the course

--- a/content/workshops/upcoming.md
+++ b/content/workshops/upcoming.md
@@ -1,7 +1,7 @@
 +++
 title = "Upcoming and recent workshops and events"
 description = "Upcomng CodeRefinery workshops and other related events."
-date = 2025-06-15
+date = 2025-07-09
 +++
 
 ## Upcoming CodeRefinery workshops
@@ -9,7 +9,7 @@ date = 2025-06-15
 <!-- If you edit this section, also update the date on top of this page. This
 is important for RSS feed. -->
 
-- CodeRefinery tools workshop (online) - September 9-11 2025 + 6 following Wednesdays (new format - registration opening soon!)
+- [CodeRefinery tools workshop (online)](https://coderefinery.github.io/2025-09-09-workshop/) - September 9-11 2025 + 6 following Wednesdays (new format - registration opening soon!)
 
 Don't want you to miss a workshop or event? The best
 way to stay informed is to join [our newsletter](@/about/newsletter.md)


### PR DESCRIPTION
With registration still closed for a moment

Review includes review of the workshop page: https://coderefinery.github.io/2025-09-09-workshop/

Thank you!